### PR TITLE
yaml night ranges & yaml doc & bugfixes ReadCalibration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Éric Thiébaut <eric.thiebaut@univ-lyon1.fr> and contributors"]
 version = "0.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EasyFITS = "a977f4a2-36a7-4172-89e7-19c2726f82e5"
 ScientificDetectors = "7137afbe-ade3-4903-9296-05966c540d95"
 SimpleExpressions = "bfa79951-833f-460b-a5a3-57213acc08ae"

--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ calib = ReducedCalibration(data)
 A YAML file should be as follow :
 
 ```yaml
-title: Detector calibration
-
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true
 exclude files: M.
 
 exptime: "ESO DET1 SEQ1 DIT"
+
+DATE-OBS:
+    min: 2022-04-01
+    max: 2022-04-13T12:24:10.003
 
 categories:
   DARK:
@@ -58,7 +60,7 @@ The mandatory keywords are:
 - `categories` : lists all calibration categories (e.g. FLAT, DARK,...)
 - `sources` : the sources corresponding to the parent category (mandatory for each category).
 
-In this example, the calibration files are identified by their `ESO DPR TYPE` keyword.  If several values are allowed, they can be given in a array (as for the `WAVE` category in this example). If several keywords are given (as for the `FLAT` category) all of them must be valid.
+In this example, the calibration files are identified by their `ESO DPR TYPE` keyword.  If several values are allowed, they can be given in a array (as for the `WAVE` category in this example). If several keywords are given (as for the `FLAT` category) all of them must be valid. A date range can also be given, see more info below.
 
 Optional keywords are:
 
@@ -70,3 +72,12 @@ Optional keywords are:
 - `hdu` : name of the FITS HDU that contains the data (default `primary`).
 
 All the keywords given in the root of the file are set for all the categories (as `suffixes` in the example) but this can be overiden by keywords in each category (as `exptime` in the example).
+
+It is possible to restrict the calibration files by a range of dates:
+```yaml
+DATE-OBS:
+    min: 2022-04-01
+    max: 2022-04-13T12:24:10.003
+```
+Only files respecting `min <= file["DATE-OBS"] < max` are kept.
+

--- a/doc/src/yaml_syntax.md
+++ b/doc/src/yaml_syntax.md
@@ -1,0 +1,278 @@
+# The YAML syntax for AstronomicalDetectors
+
+Instead of manually retrieving files for your categories, you can give a YAML file to
+AstronomicalDetectors. This file defines the categories, the sources associated to each category,
+and the filters to choose the files associated to each category.
+
+Summary:
+- [Structure](#structure)
+- [Available Settings](#available-settings)
+- [Available Filters](#available-filters)
+- [Example with comments](#example-with-comments)
+
+## Structure
+
+```
+global settings
+global filters
+categories
+```
+
+### Global Settings
+
+The settings for AstronomicalDetectors. For example the setting `dir`:
+
+```yaml
+dir: alice/calibration-files/
+```
+
+`dir` is the name of the setting and `alice/calibration-files/` is the value of the setting.
+This one tells AstronomicalDetectors the folder in which to look for FITS files.
+
+The setting `exptime` is mandatory.
+
+### Global Filters
+
+A filter consist of a FITS header keyword name and value. For example:
+
+```yaml
+INSTRUME: SPHERE
+```
+
+`INSTRUME` is the name of the FITS keyword and `SPHERE` is the value of type `String`.
+
+When you specify a filter, AstronomicalDetectors only keeps files respecting that filter. In the
+previous example, it means that every kept file has a `INSTRUME` keyword in its header with
+the value `SPHERE`.
+
+Several filters act as an "AND": all of them must hold to keep the file.
+
+### Categories
+
+Where you describe the categories. A category has the following structure:
+
+```
+categories:
+    NAME:
+        category settings
+        category filters
+```
+`categories:` is the line announcing the categories section, you write it only once in the file.
+
+`NAME` is the name of the category. We always write them in upper case, to distinguish them from
+sources names, but it is not mandatory.
+
+`category settings` are just like `global settings` but they only apply to the current category.
+For example if you give the setting `dir: other-folder/`, AstronomicalDetectors will use the
+folder `other-folder/`, instead of the one defined globaly.\
+In each category the setting `sources` is mandatory.
+
+`category filters` are just like `global filters` but they only apply to the current category. For
+exanple if you give the filter `NAXIS1: 1024`, every file in the category must have a header
+keyword `NAXIS1` with the value `1024`.
+
+You must indent categories (with spaces, tabs are forbidden).
+
+Any category setting hides any global setting of the same name. It is the same for filters.
+
+## Available Settings
+
+Names of the settings must be in lower case.
+
+### exptime
+
+The setting `exptime` gives a keyword name, that keyword must contain the information of the
+integration time.
+
+Type is `String`.
+
+Mandatory (it has no default value).
+
+### sources
+
+The setting `sources` gives the sources (or "currents") present in the files of the category.
+For example the category FLATS may contain a dark current and a flat current. This would be
+written as:
+
+```yaml
+sources: dark + flat
+```
+
+We write sources names in mostly lower case, to distinguish them from categories, but it is not
+mandatory. However, they must only be composed of ASCII letters, digits, and underscores.\
+Any number at the beginning of a source name acts as a coefficient for that source. For example in
+`3dark` or in `1.5dark`, the coefficients are `3` and `1.5`. Coefficients are not part of the
+sources names.
+
+Only category setting.\
+Mandatory for each category (it has no default value).
+
+### dir
+
+The setting `dir` instructs in which folder to look. Absolute and relative paths are accepted.
+
+Type is `String`.
+
+When unspecified, the one given to the Julia function is used, and when also unspecified,
+working directory is used.
+
+### include subdirectory
+
+The setting `include subdirectory`, if `true`, instructs to search in the sub folders too.
+
+Type is `Bool`.
+
+When unspecified, `true` is used.
+
+### hdu
+
+The setting `hdu` gives the number of the FITS HeaderDataUnit to use.
+
+Type is `Int`.
+
+When unspecified, `1` is used, which points to the primary HDU.
+
+### suffixes
+
+The setting `suffixes` gives the accepted extensions for the files. Only files whose filename ends
+in at least one of the given `String` is kept.
+
+Type is `List of String`.
+
+When unspecified, `[.fits, .fits.gz, .fits.Z]` is used.
+
+### exclude files
+
+The setting `exclude files` gives the substring that makes a filename rejected. Any file whose
+filename contains at least one of the given `String` is rejected.
+
+Type is `List of String`
+
+When unspecified, `[]` is used.
+
+### roi
+
+The setting `roi` gives the Region Of Interest of the detector.
+
+Type is `List of String of size 2`. But the `String` is in the form of a Julia `UnitRange`, for
+example `100:493`.
+
+When unspecified, the one given to the Julia function is used, and when also unspecified, `[:, :]`
+is used, which means the whole array is used.
+
+Only global setting.
+
+### files
+
+The setting `files` gives a list of additional files to take.
+
+They are still subject to the settings `exclude files` and `suffixes`.
+A category setting for `files` hides a global setting for `files`.
+
+Type is `List of String`.
+
+When unspecified, `[]` is used.
+
+## Available Filters
+
+You can define the filters on any FITS keyword. Since FITS keywords are upper case, and settings are
+lower case, there is no name conflict.
+
+Several filters act as an "AND": all of them must hold to keep the file.
+
+## Single target value
+
+Note that YAML does not impose quotes to define a String. All the following filters have one
+String target value:
+
+```yaml
+ESO DPR TYPE: DARK
+ESO DPR TYPE: DARK,BACKGROUND
+ESO DRP TYPE: "DARK,BACKGROUND"
+```
+
+The second and third lines are equivalent.
+
+You can also give Bool, Integer, and AbstractFloat values. Complex, empty and null values
+are not supported yet.
+
+You can mix different Integer values, like `Int32` and `Int64`, since they will be compared
+by `==`. It is the same for AbstractFloat values. However, mixing values of different kinds
+(String, Integer, AbstractFloat, Bool) will exclude the file and produce a warning. For example,
+asking a `3.0` float for a `3` integer keyword `NAXIS` will be false.
+
+## Multiple target values
+
+You can use YAML arrays to define multiple target values. They are considered as an "OR": at least
+one of the target values must hold to keep the file.
+
+For example if your FITS files have two ways of writing the same keyword value:
+```yaml
+ESO DPR TYPE:  ["LAMP,WAVE", "WAVE,LAMP"]
+```
+Both "LAMP,WAVE" and "WAVE,LAMP" values are accepted. One of them must hold.
+
+## Date range
+
+For DateTime keywords, you can specify a range of dates. Inferior bound is inclusive and superior
+bound is exclusive.
+
+```yaml
+DATE-OBS:
+    min: 2022-04-01
+    max: 2022-04-13T12:24:10.003
+```
+Only files with 2022-04-01 <= file[DATE-OBS] < 2022-04-13T12:24:10.003 will be kept.
+
+Note that because of the limitations of the YAML library we use, if you use four digits after the
+second, the fourth one is truncated. So `2022-04-13T12:24:10.0039` is changed to
+`2022-04-13T12:24:10.003`.
+
+## Example with comments
+
+```yaml
+# We start to define our global settings
+
+# directory path where files will be looked for
+dir:  alice/calibration-files/
+
+# if true, sub directories will be searched too
+include subdirectory: true
+
+# only files whose filename ends with at least one of these suffixes will be kept
+suffixes: [.fits, .fits.gz,.fits.Z]
+
+# AstronomicalDetectors needs to know the integration time.
+# we specify which keyword contains this information.
+exptime: "ESO DET SEQ1 DIT"
+
+# We start to define our global filters
+
+# This is a filter that will be applied to every file.
+# INSTRUME is a keyword name. SPHERE is the target value.
+# Only files whose header have INSTRUME keyword with value SPHERE will be kept.
+INSTRUME: SPHERE
+
+# Here we want to restrict the files by a range of DateTime for the keyword DATE-OBS.
+DATE-OBS:
+    min: 2022-04-01                # inferior bound (inclusive)
+    max: 2022-04-13T12:24:10.003   # superior bound (exclusive)
+
+# We start to define our categories
+
+categories:
+  FLAT:   # a first category, of name "FLAT"
+    sources: background + flat   # two sources : "background" and "flat"
+    ESO INS COMB IFLT: BB_H      # a filter for this category
+    ESO DPR TYPE: FLAT,LAMP      # another
+
+  BACKGROUND:  # another category, of name "BACKGROUND"
+    sources: background
+    ESO DPR TYPE: ["DARK", "DARK,BACKGROUND"]   # at least one of these values must hold
+
+  WAVE:
+    sources: background + wave
+    dir: alice/wave-calibration-folder  # changing the `dir` setting for this category
+    exptime: "SPECIAL DIT KEYWORD"      # changing the `exptime` setting for this category
+    ESO DPR TYPE: ["LAMP,WAVE","WAVE,LAMP"]
+```

--- a/test/example_from_the_doc.yml
+++ b/test/example_from_the_doc.yml
@@ -1,0 +1,44 @@
+# We start to define our global settings
+
+# directory path where files will be looked for
+dir:  alice/calibration-files/
+
+# if true, sub directories will be searched too
+include subdirectory: true
+
+# only files whose filename ends with at least one of these suffixes will be kept
+suffixes: [.fits, .fits.gz,.fits.Z]
+
+# AstronomicalDetectors needs to know the integration time.
+# we specify which keyword contains this information.
+exptime: "ESO DET SEQ1 DIT"
+
+# We start to define our global filters
+
+# This is a filter that will be applied to every file.
+# INSTRUME is a keyword name. SPHERE is the target value.
+# Only files whose header have INSTRUME keyword with value SPHERE will be kept.
+INSTRUME: SPHERE
+
+# Here we want to restrict the files by a range of DateTime for the keyword DATE-OBS.
+DATE-OBS:
+    min: 2022-04-01                # inferior bound (inclusive)
+    max: 2022-04-13T12:24:10.003   # superior bound (exclusive)
+
+# We start to define our categories
+
+categories:
+  FLAT:   # a first category, of name "FLAT"
+    sources: background + flat   # two sources : "background" and "flat"
+    ESO INS COMB IFLT: BB_H      # a filter for this category
+    ESO DPR TYPE: FLAT,LAMP      # another
+
+  BACKGROUND:  # another category, of name "BACKGROUND"
+    sources: background
+    ESO DPR TYPE: ["DARK", "DARK,BACKGROUND"]   # at least one of these values must hold
+
+  WAVE:
+    sources: background + wave
+    dir: alice/wave-calibration-folder  # changing the `dir` setting for this category
+    exptime: "SPECIAL DIT KEYWORD"      # changing the `exptime` setting for this category
+    ESO DPR TYPE: ["LAMP,WAVE","WAVE,LAMP"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using AstronomicalDetectors
 using Test
 using EasyFITS
+using Dates
+using AstronomicalDetectors.YAMLCalibrationFiles
+using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
 
 @testset "AstronomicalDetectors.jl" begin
     # Write your tests here.
@@ -77,20 +80,150 @@ using EasyFITS
 end
 
 @testset "ReadCalibration.jl" begin
-    @testset "filtercat(filelist,keyword,value::T)" begin
-        filtercat = AstronomicalDetectors.YAMLCalibrationFiles.filtercat
+
+    @testset "filtercat single value" begin
         hdr = FitsHeader(
             "QUESTION" => "What is the answer?",
             "ANSWER" => 42,
             "CLEVER" => false,
             "HALF" => 1.5,
-            "VOID" => nothing)
-        dict = Dict("file" => hdr)
+            "VOID" => nothing,
+            "ESO INFORMATIVE MESSAGE" => "I like my keyword names to be long")
+        dict = Dict("file1" => hdr)
         @test !isempty(filtercat(dict, "QUESTION", "What is the answer?"))
         @test !isempty(filtercat(dict, "ANSWER", 42))
         @test !isempty(filtercat(dict, "CLEVER", false))
-        @test !isempty(filtercat(dict, "HALF", 1.5))
-        @test !isempty(filtercat(dict, "VOID", nothing))
-        @test isempty(filtercat(dict, "VOID", "something"))
+        @test !isempty(filtercat(dict, "HALF", 1.5e0))
+        @test !isempty(filtercat(dict, "HALF", 1.5f0))
+        @test !isempty(filtercat(dict, "ANSWER", Int8(42)))
+        @test !isempty(filtercat(dict, "ANSWER", UInt64(42)))
+        warnmsg = "card type Float64 is != from target value type String in file file1"
+        @test_warn warnmsg filtercat(dict, "HALF", "1.5")
+        errormsg = "Complex values not yet implemented"
+        @test_throws ErrorException(errormsg) filtercat(dict, "HALF", 1.5+0im)
+        warnmsg = "card type Float64 is != from target value type Int64 in file file1"
+        @test_warn warnmsg filtercat(dict, "HALF", 1)
+        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
+        @test_warn warnmsg filtercat(dict, "ANSWER", 42e0)
+        errormsg = "unsupported target value type Nothing"
+        @test_throws ErrorException(errormsg) filtercat(dict, "VOID", nothing)
+        warnmsg = "card type Nothing is != from target value type String in file file1"
+        @test_warn warnmsg filtercat(dict, "VOID", "something")
+        @test !isempty(filtercat(dict, "ESO INFORMATIVE MESSAGE",
+                                       "I like my keyword names to be long"))
+    end
+
+    @testset "filtercat several value" begin
+        hdr = FitsHeader("GOOD" => 2)
+        dict = Dict("file1" => hdr)
+        @test !isempty(filtercat(dict, "GOOD", [1, 2]))
+        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
+        @test_warn warnmsg filtercat(dict, "GOOD", [1.0, 2.0])
+        errormsg = "eltype Any of the Vector target value is not supported"
+        @test_throws ErrorException(errormsg) filtercat(dict, "GOOD", [1, "2"])
+    end
+
+    @testset "filtercat date range" begin
+        # date range
+        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
+        keyword = "DATE"
+        value = Dict{String,Any}(
+            "min" => DateTime("2022-11-20T08:00:10.123"),
+            "max" => DateTime("2024-11-20T08:00:10.123"))
+        filelist2 = filtercat(filelist, keyword, value)
+        @test filelist == filelist2
+
+        # date range with fitsheader date with fourth millisecond in FITS file
+        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.1234"))
+        keyword = "DATE"
+        value = Dict{String,Any}(
+            "min" => DateTime("2022-11-20T08:00:10.123"),
+            "max" => DateTime("2024-11-20T08:00:10.123"))
+        filelist2 = filtercat(filelist, keyword, value)
+        @test filelist == filelist2
+
+        # date range exclude
+        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
+        keyword = "DATE"
+        value = Dict{String,Any}(
+            "min" => DateTime("2022-11-20T08:00:10.123"),
+            "max" => DateTime("2023-11-20T08:00:10.123"))
+        filelist2 = filtercat(filelist, keyword, value)
+        @test isempty(filelist2)
+
+        # date range include
+        filelist = Dict("TOTO" => FitsHeader("DATE" => "2022-11-20T08:00:10.123"))
+        keyword = "DATE"
+        value = Dict{String,Any}(
+            "min" => DateTime("2022-11-20T08:00:10.123"),
+            "max" => DateTime("2023-11-20T08:00:10.123"))
+        filelist2 = filtercat(filelist, keyword, value)
+        @test filelist == filelist2
+
+        # yaml file, with a test with fourth millisecond
+        mktemp()        do pathyaml,fileio
+        mktempdir()     do pathdir
+        mktemp(pathdir) do pathfits,fileio
+
+            hdr = FitsHeader("DATE" => "2023-11-20T08:00:10.1234", "TIME" => 1.1)
+            yaml = """
+                   suffixes: [$pathfits]
+                   exptime: "TIME"
+                   categories:
+                     TOTO:
+                       DATE:
+                           min: 2022-11-20T08:00:10.1234
+                           max: 2024-11-20T08:00:10.1234
+                       sources: toto
+                   """
+            write(pathyaml, yaml)
+            writefits!(pathfits, hdr, Int[0 0 ; 0 0])
+            ReadCalibrationFiles(pathyaml; dir=pathdir)
+
+        end end end
+    end
+
+    @testset "ReadCalibrationFiles with example_from_the_doc.yml" begin
+        initialdir = pwd()
+        try
+            mktempdir() do pathdir
+
+                cd(pathdir)
+
+                # build directory structure like in the example
+                mkdir("alice")
+                mkdir("alice/calibration-files")
+                mkdir("alice/calibration-files/subfolder")
+                mkdir("alice/wave-calibration-folder")
+
+                hdr1 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
+                                  "DATE-OBS" => "2022-04-05",
+                                  "ESO INS COMB IFLT" => "BB_H", "ESO DPR TYPE" => "FLAT,LAMP")
+                writefits!("alice/calibration-files/file1.fits", hdr1, [1;;])
+
+                hdr2 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
+                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "DARK")
+                writefits!("alice/calibration-files/subfolder/file2.fits", hdr2, [1;;])
+
+                hdr3 = FitsHeader("SPECIAL DIT KEYWORD" => 1e0, "INSTRUME" => "SPHERE",
+                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "LAMP,WAVE")
+                writefits!("alice/wave-calibration-folder/file3.fits", hdr3, [1;;])
+
+                # put one in a wrong folder to see if it is correctly excluded
+                writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
+
+                data = ReadCalibrationFiles(initialdir * "/test/example_from_the_doc.yml")
+
+                @test "FLAT"       in keys(data.cat_index)
+                @test "BACKGROUND" in keys(data.cat_index)
+                @test "WAVE"       in keys(data.cat_index)
+                @test "flat"       in keys(data.src_index)
+                @test "background" in keys(data.src_index)
+                @test "wave"       in keys(data.src_index)
+                @test data.stat[data.stat_index[("FLAT",1)      ]].n == 1
+                @test data.stat[data.stat_index[("BACKGROUND",1)]].n == 1
+                @test data.stat[data.stat_index[("WAVE",1)      ]].n == 1
+            end
+        finally cd(initialdir) end
     end
 end

--- a/zoo/GRAVITY_ACQ_calibration.yml
+++ b/zoo/GRAVITY_ACQ_calibration.yml
@@ -1,5 +1,3 @@
-title: GRAVITY acquisition detector calibration
-
 dir: /Users/ferreol/Data/Gravity+/2020-03-09_MEDIUM_COMBINED/
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true

--- a/zoo/GRAVITY_SC_calibration.yml
+++ b/zoo/GRAVITY_SC_calibration.yml
@@ -1,6 +1,3 @@
-title: GRAVITY science detector calibration
-
-
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: false
 exclude files: M.

--- a/zoo/SPHERE IRDIS calibration.yml
+++ b/zoo/SPHERE IRDIS calibration.yml
@@ -1,5 +1,3 @@
-title: SPHERE IRDIS calibration
-
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true
 exclude files: M.

--- a/zoo/ZIMPOL detector calibration.yml
+++ b/zoo/ZIMPOL detector calibration.yml
@@ -1,6 +1,3 @@
-title: ZIMPOL detector calibration
-
-
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true
 exclude files: M.


### PR DESCRIPTION
⚠ not ready to merge yet ⚠

In the YAML file, adds the possibility to give night ranges for the "DATE-OBS" keyword, like this:

```yaml
DATE-OBS:
    min: 2022-06-01
    max: 2022-06-03T12:24:48.777
```
It permits to restrict the selected files by date.

It only works for `Date` ranges for now, with `min` and `max` keywords given under the keyword. The keyword can be anything, not just "DATE-OBS". It also works for keywords defined inside categories.

Also add documentation about yaml files

Also contains some bug fixes in ReadCalibration.jl 
