### PR TITLE
Refactoring YAML Config

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Éric Thiébaut <eric.thiebaut@univ-lyon1.fr> and contributors"]
 version = "0.1.0"
 
 [deps]
+BaseFITS = "b056ee54-6bb4-44e7-9abb-abfb59909e18"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EasyFITS = "a977f4a2-36a7-4172-89e7-19c2726f82e5"
 ScientificDetectors = "7137afbe-ade3-4903-9296-05966c540d95"

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Usage:
 
 ```julia
 using AstronomicalDetectors, ScientificDetectors
-data = ReadCalibrationFiles("ymlfile.yml"; dir="path/to/calib/folder")
+data = read_calibration_files_from_yaml("ymlfile.yml"; basedir="path/to/calib/folder")
 calib = ReducedCalibration(data)
 ```
 
-A YAML file should be as follow :
+A YAML configuration file can be as follow :
 
 ```yaml
 suffixes: [.fits, .fits.gz,.fits.Z]
-include subdirectory: true
+include subdirectories: true
 exclude files: M.
 
 exptime: "ESO DET1 SEQ1 DIT"
@@ -54,30 +54,12 @@ categories:
     sources: dark + wave
 ```
 
-The mandatory keywords are:
+The mandatory parts are:
 
 - `exptime` : the FITS keyword containing the integration time
 - `categories` : lists all calibration categories (e.g. FLAT, DARK,...)
 - `sources` : the sources corresponding to the parent category (mandatory for each category).
 
-In this example, the calibration files are identified by their `ESO DPR TYPE` keyword.  If several values are allowed, they can be given in a array (as for the `WAVE` category in this example). If several keywords are given (as for the `FLAT` category) all of them must be valid. A date range can also be given, see more info below.
+In this example, the calibration files are identified by their `ESO DPR TYPE` keyword.  If several values are allowed, they can be given in a array (as for the `WAVE` category in this example). If several keywords are given (as for the `FLAT` category) all of them must be valid. A date range can also be given, as for `DATE-OBS`.
 
-Optional keywords are:
-
-- `dir` :  the folder containing the calibration files (default `pwd`),
-- `files` : list of files or pattern,
-- `suffixes` : suffixes of the files  (default `[.fits, .fits.gz,.fits.Z]`),
-- `include subdirectory` : if `true` parse all subdirectories
-- `exclude files` : patterns of files that must be excluded
-- `hdu` : name of the FITS HDU that contains the data (default `primary`).
-
-All the keywords given in the root of the file are set for all the categories (as `suffixes` in the example) but this can be overiden by keywords in each category (as `exptime` in the example).
-
-It is possible to restrict the calibration files by a range of dates:
-```yaml
-DATE-OBS:
-    min: 2022-04-01
-    max: 2022-04-13T12:24:10.003
-```
-Only files respecting `min <= file["DATE-OBS"] < max` are kept.
-
+Find more information about YAML configuration in the "doc/" folder.

--- a/doc/src/yaml_syntax.md
+++ b/doc/src/yaml_syntax.md
@@ -152,7 +152,7 @@ Names of the settings are case sensitive. They are all in lower case, to disting
 filters which are FITS keywords (upper case).
 
 - **exptime**
-  
+
   Contains a FITS keyword name, that keyword must contain the information of the
 exposure time.\
   Type is `String`.\
@@ -278,8 +278,8 @@ sources names.
   Aliases are `follow_symbolic_links`.
   ```yaml
   follow symbolic links: true
-  ``` 
-  
+  ```
+
 - **title**
 
   Gives an informative title to the config.\

--- a/doc/src/yaml_syntax.md
+++ b/doc/src/yaml_syntax.md
@@ -5,236 +5,22 @@ AstronomicalDetectors. This file defines the categories, the sources associated 
 and the filters to choose the files associated to each category.
 
 Summary:
-- [Structure](#structure)
-- [Available Settings](#available-settings)
-- [Available Filters](#available-filters)
+
 - [Example with comments](#example-with-comments)
+- [Structure](#structure)
+- [Settings](#settings)
+- [Filters](#filters)
 
-## Structure
-
-```
-global settings
-global filters
-categories
-```
-
-### Global Settings
-
-The settings for AstronomicalDetectors. For example the setting `dir`:
-
-```yaml
-dir: alice/calibration-files/
-```
-
-`dir` is the name of the setting and `alice/calibration-files/` is the value of the setting.
-This one tells AstronomicalDetectors the folder in which to look for FITS files.
-
-The setting `exptime` is mandatory.
-
-### Global Filters
-
-A filter consist of a FITS header keyword name and value. For example:
-
-```yaml
-INSTRUME: SPHERE
-```
-
-`INSTRUME` is the name of the FITS keyword and `SPHERE` is the value of type `String`.
-
-When you specify a filter, AstronomicalDetectors only keeps files respecting that filter. In the
-previous example, it means that every kept file has a `INSTRUME` keyword in its header with
-the value `SPHERE`.
-
-Several filters act as an "AND": all of them must hold to keep the file.
-
-### Categories
-
-Where you describe the categories. A category has the following structure:
-
-```
-categories:
-    NAME:
-        category settings
-        category filters
-```
-`categories:` is the line announcing the categories section, you write it only once in the file.
-
-`NAME` is the name of the category. We always write them in upper case, to distinguish them from
-sources names, but it is not mandatory.
-
-`category settings` are just like `global settings` but they only apply to the current category.
-For example if you give the setting `dir: other-folder/`, AstronomicalDetectors will use the
-folder `other-folder/`, instead of the one defined globaly.\
-In each category the setting `sources` is mandatory.
-
-`category filters` are just like `global filters` but they only apply to the current category. For
-exanple if you give the filter `NAXIS1: 1024`, every file in the category must have a header
-keyword `NAXIS1` with the value `1024`.
-
-You must indent categories (with spaces, tabs are forbidden).
-
-Any category setting hides any global setting of the same name. It is the same for filters.
-
-## Available Settings
-
-Names of the settings must be in lower case.
-
-### exptime
-
-The setting `exptime` gives a keyword name, that keyword must contain the information of the
-integration time.
-
-Type is `String`.
-
-Mandatory (it has no default value).
-
-### sources
-
-The setting `sources` gives the sources (or "currents") present in the files of the category.
-For example the category FLATS may contain a dark current and a flat current. This would be
-written as:
-
-```yaml
-sources: dark + flat
-```
-
-We write sources names in mostly lower case, to distinguish them from categories, but it is not
-mandatory. However, they must only be composed of ASCII letters, digits, and underscores.\
-Any number at the beginning of a source name acts as a coefficient for that source. For example in
-`3dark` or in `1.5dark`, the coefficients are `3` and `1.5`. Coefficients are not part of the
-sources names.
-
-Only category setting.\
-Mandatory for each category (it has no default value).
-
-### dir
-
-The setting `dir` instructs in which folder to look. Absolute and relative paths are accepted.
-
-Type is `String`.
-
-When unspecified, the one given to the Julia function is used, and when also unspecified,
-working directory is used.
-
-### include subdirectory
-
-The setting `include subdirectory`, if `true`, instructs to search in the sub folders too.
-
-Type is `Bool`.
-
-When unspecified, `true` is used.
-
-### hdu
-
-The setting `hdu` gives the number of the FITS HeaderDataUnit to use.
-
-Type is `Int`.
-
-When unspecified, `1` is used, which points to the primary HDU.
-
-### suffixes
-
-The setting `suffixes` gives the accepted extensions for the files. Only files whose filename ends
-in at least one of the given `String` is kept.
-
-Type is `List of String`.
-
-When unspecified, `[.fits, .fits.gz, .fits.Z]` is used.
-
-### exclude files
-
-The setting `exclude files` gives the substring that makes a filename rejected. Any file whose
-filename contains at least one of the given `String` is rejected.
-
-Type is `List of String`
-
-When unspecified, `[]` is used.
-
-### roi
-
-The setting `roi` gives the Region Of Interest of the detector.
-
-Type is `List of String of size 2`. But the `String` is in the form of a Julia `UnitRange`, for
-example `100:493`.
-
-When unspecified, the one given to the Julia function is used, and when also unspecified, `[:, :]`
-is used, which means the whole array is used.
-
-Only global setting.
-
-### files
-
-The setting `files` gives a list of additional files to take.
-
-They are still subject to the settings `exclude files` and `suffixes`.
-A category setting for `files` hides a global setting for `files`.
-
-Type is `List of String`.
-
-When unspecified, `[]` is used.
-
-## Available Filters
-
-You can define the filters on any FITS keyword. Since FITS keywords are upper case, and settings are
-lower case, there is no name conflict.
-
-Several filters act as an "AND": all of them must hold to keep the file.
-
-## Single target value
-
-Note that YAML does not impose quotes to define a String. All the following filters have one
-String target value:
-
-```yaml
-ESO DPR TYPE: DARK
-ESO DPR TYPE: DARK,BACKGROUND
-ESO DRP TYPE: "DARK,BACKGROUND"
-```
-
-The second and third lines are equivalent.
-
-You can also give Bool, Integer, and AbstractFloat values. Complex, empty and null values
-are not supported yet.
-
-You can mix different Integer values, like `Int32` and `Int64`, since they will be compared
-by `==`. It is the same for AbstractFloat values. However, mixing values of different kinds
-(String, Integer, AbstractFloat, Bool) will exclude the file and produce a warning. For example,
-asking a `3.0` float for a `3` integer keyword `NAXIS` will be false.
-
-## Multiple target values
-
-You can use YAML arrays to define multiple target values. They are considered as an "OR": at least
-one of the target values must hold to keep the file.
-
-For example if your FITS files have two ways of writing the same keyword value:
-```yaml
-ESO DPR TYPE:  ["LAMP,WAVE", "WAVE,LAMP"]
-```
-Both "LAMP,WAVE" and "WAVE,LAMP" values are accepted. One of them must hold.
-
-## Date range
-
-For DateTime keywords, you can specify a range of dates. Inferior bound is inclusive and superior
-bound is exclusive.
-
-```yaml
-DATE-OBS:
-    min: 2022-04-01
-    max: 2022-04-13T12:24:10.003
-```
-Only files with 2022-04-01 <= file[DATE-OBS] < 2022-04-13T12:24:10.003 will be kept.
-
-Note that because of the limitations of the YAML library we use, if you use four digits after the
-second, the fourth one is truncated. So `2022-04-13T12:24:10.0039` is changed to
-`2022-04-13T12:24:10.003`.
 
 ## Example with comments
 
 ```yaml
 # We start to define our global settings
 
-# directory path where files will be looked for
-dir:  alice/calibration-files/
+title: "A YAML config example"
+
+# directory path where files will be looked for.
+dir:  /home/alice/calibration-files/
 
 # if true, sub directories will be searched too
 include subdirectory: true
@@ -272,7 +58,299 @@ categories:
 
   WAVE:
     sources: background + wave
-    dir: alice/wave-calibration-folder  # changing the `dir` setting for this category
-    exptime: "SPECIAL DIT KEYWORD"      # changing the `exptime` setting for this category
+    dir: /home/alice/wave-calibration-folder # changing the `dir` setting for this category
+    exptime: "SPECIAL DIT KEYWORD"           # changing the `exptime` setting for this category
     ESO DPR TYPE: ["LAMP,WAVE","WAVE,LAMP"]
 ```
+
+## Structure
+
+```
+global settings
+global filters
+categories
+```
+
+Note that putting global settings and filters in a random order, including after the categories, is
+allowed, since the YAML will be parsed to a dictionnary.
+
+### Global Settings
+
+The settings for AstronomicalDetectors. For example the setting `dir`:
+
+```yaml
+dir: /home/alice/calibration-files/
+```
+
+`dir` is the name of the setting and `/home/alice/calibration-files/` is the value of the setting.
+This one tells AstronomicalDetectors the folder in which to look for FITS files.
+
+### Global Filters
+
+A filter consist of a FITS header keyword name and value. For example:
+
+```yaml
+INSTRUME: SPHERE
+```
+
+`INSTRUME` is the name of the FITS keyword and `SPHERE` is the value of type `String`.
+
+When you specify a filter, AstronomicalDetectors only keeps files respecting that filter. In the
+previous example, it means that every kept file has a `INSTRUME` keyword in its header with
+the value `SPHERE`.
+
+Several filters act as an "AND": all of them must hold to keep the file.
+
+### Categories
+
+Where you describe the categories.
+
+A category is a "type" of file, in the sense that you can apply
+the "pixel-wise mean" on several files of the same category, and it makes sense. For example, you
+can compute the mean of several "flat" calibration files with the same exposure conditions and the
+same exposure time.\
+Your work is to define the list of categories and how to distinguish them. You don't have to
+distinguish them by the exposure time: ScientificDetectors will do this for you. It will group the
+files by exposure time inside each category you defined.
+
+A category is defined by a name, some AstronomicalDetectors settings, and some filters to decide
+which files will belong to the category:
+
+```
+categories:
+    NAME:
+        category settings
+        category filters
+```
+
+`categories:` is the line announcing the categories section, you write it only once in the file.
+
+`NAME` is the name of the category. We always write them in upper case, to distinguish them from
+sources names, but it is not mandatory.
+
+`category settings` are like `global settings` but they only apply to the current category.
+For example if you give the setting `dir: /other-folder/`, AstronomicalDetectors will use the
+folder `/other-folder/`, instead of the one defined globaly.
+
+`category filters` are just like `global filters` but they only apply to the current category. For
+exanple if you give the filter `NAXIS1: 1024`, every file in the category must have a header
+keyword `NAXIS1` with the value `1024`.
+
+Any category setting hides any global setting of the same name. It is the same for filters.
+
+In each category the setting `sources` is mandatory. It describes which light currents are present
+in the files, and ScientificDetectors will do his best to find the flux of each of these currents.
+Typically you can have a "DARK" category with a "dark" source, and a "FLAT" category with sources
+"flat + dark", which means each FLAT file has received two currents: one from the lamp ("flat") and
+one from the dark current ("dark").
+
+You must indent categories (with spaces, tabs are forbidden in YAML indentation).
+
+## Settings
+
+Names of the settings are case sensitive. They are all in lower case, to distinguish them from
+filters which are FITS keywords (upper case).
+
+- **exptime**
+  
+  Contains a FITS keyword name, that keyword must contain the information of the
+exposure time.\
+  Type is `String`.\
+  Can be present as global and in categories.\
+  Mandatory (it has no default value). You can define it globally or in each category.
+  ```yaml
+  exptime: ESO DET SEQ1 DIT
+  ```
+- **sources**
+
+  Contains the sources (or "currents") present in the files of the category.
+  Type is `String`.
+  For example the category FLAT may contain a dark current and a flat current:
+  ```yaml
+  categories:
+      FLAT:
+          sources: dark + flat
+  ```
+  We write sources names in mostly lower case, to distinguish them from categories, but it is not
+mandatory. However, they must only be composed of ASCII letters, digits, and underscores.\
+  Any number at the beginning of a source name acts as a coefficient for that source. For example in
+`3dark` or in `1.5dark`, the coefficients are `3` and `1.5`. Coefficients are not part of the
+sources names.
+  Can be present in categories.\
+  Mandatory (it has no default value).
+
+- **dir**
+
+  Gives in which folder to look.
+  Type is `String`.
+  Absolute and relative paths are accepted. When using relative path, it will be resolve from the
+  current working dir of the calling script. In the API you can specify a `basedir` keyword to
+  choose the folder from which to resolve relative paths.\
+  Note that the category setting `dir` overwrites the global setting `dir`, don't mistake it as a
+  relative path from the global setting `dir`.\
+  Can be present as global setting and in categories.\
+  Default value is ".".
+  ```yaml
+  dir: /home/alice/calib-folder
+  ```
+
+- **include subdirectories**
+
+  Says if we must look for FITS files recursively in the sub folders of the folder `dir`.\
+  Type is `Bool`.\
+  Can be present as global setting and in categories.\
+  Default is `true`.\
+  Aliases are `include subdirectory`, `include_subdirectory`, `include_subdirectories`.
+  ```yaml
+  include subdirectories: true
+  ```
+
+- **hdu**
+
+  Gives the index number of the FITS HeaderDataUnit to use. It can also be the HDUNAME.\
+  Type is `Int` or `String`.\
+  Can be present as global setting and in categories.\
+  Default is `1` (primary HDU).
+  ```yaml
+  hdu: "DETECTOR_DATA"
+  ```
+
+- **suffixes**
+
+  Gives the accepted extensions for the files.\
+  Only files whose filename ends in at least one of the given `String` is kept.\
+  Type is `List of String` or `String`.\
+  Can be present as global setting and in categories.\
+  Default is `[.fits, .fits.gz, .fits.Z]`.
+  ```yaml
+  suffixes: [.fits, ".fitsyfits", .fits.Z]
+  suffixes: .fits.gz.Z.zip  # if you only have one you can omit the [ ]
+  ```
+
+- **exclude files**
+
+  Gives the substrings that are forbidden in the filenames.\
+  Any file whose filename contains at least one of the given `String` is rejected.\
+  Type is `List of String` or `String`.\
+  Can be present as global setting and in categories.\
+  Default is `[]`.
+  Aliases are `exclude_files`.
+  ```yaml
+  exclude files: ["useless", "archive-"]
+  ```
+
+- **roi**
+
+  Gives the Region Of Interest of the detector.\
+  Defines the inclusive first pixel, the inclusive last pixel, with an optional step whose default
+  is `1`. You are restricted to exactly two axes. To express the full axe without having to
+  hardwrite the index of its last pixel, you can use `:`.\
+  Type is `String`, but it will be parsed in Julia as `NTuple{2,Union{Colon,StepRange{Int,Int}}}`.\
+  Can be present as global setting and in categories.\
+  Default is `(:,:)` which means full ROI.\
+  You can omit the `( )`.\
+  ```yaml
+  roi: (:, 11:2:2038) # full first axe, and Step range of start 11, step 2, last 2038.
+  ```
+
+- **files**
+
+  Gives a strict list of `files` to use.\
+  When enabled, the settings `dir`, `suffixes`, `exclude files`, `include subdirectories`,
+  and `follow symbolic links`, have no effect on this list of files. However, filters will still
+  have to be valid for these files.\
+  You can use absolute or relative paths.\
+  Type is `List of String` or `String`.\
+  Can be present as global setting and in categories. As any other settings, if is defined in a
+  category it overwrites the global one.\
+  Default is `[]`, when the list is empty, it disables this setting.
+  ```yaml
+  files: ["/tmp/temp.fits", "../toto/tata.txt"]
+  ```
+- **follow symbolic links**
+
+  Says if symbolic links to folders should be followed.\
+  To be checked, but it seems that for now symbolic links to files are followed, not matter if
+  this setting is `true` or `false`.\
+  Type is `Bool`.\
+  Can be present as global setting and in categories.\
+  Default is `false`.
+  Aliases are `follow_symbolic_links`.
+  ```yaml
+  follow symbolic links: true
+  ``` 
+  
+- **title**
+
+  Gives an informative title to the config.\
+  It has no effect, it is meant as a label for the user.\
+  Type is `String`.\
+  Can be present as global setting.\
+  Default is an empty string.\
+  ```yaml
+  title: My super title
+  ```
+
+## Filters
+
+You can define the filters on any FITS keyword. Since FITS keywords are upper case, and settings are
+lower case, there is no name conflict.
+
+Several filters act as an "AND": all of them must hold to keep the file.
+
+### Filter Single target value
+
+You give a single value that must be exactly matched by the FITS files:
+
+```yaml
+CALIB_TYPE: FLAT
+```
+In the previous example, only files with a keyword `CALIB_TYPE` with value exactly `FLAT` will be
+kept.
+
+Note that YAML does not impose quotes to define a String. All the following filters have one
+String target value:
+
+```yaml
+ESO DPR TYPE: DARK,BACKGROUND
+ESO DRP TYPE: "DARK,BACKGROUND"    # both lines are equivalent
+```
+
+The types authorized for values are: Integer, String, Float, Bool, DateTime. Complex numbers are
+not supported yet.
+
+Be careful when asking Float values. The floating point FITS keywords may not represent any
+possible Double Precision value. Conversely, floating point FITS keyword can be non representable
+in Double Precision. If needed, we can add an "epsilon" to compare float values, ask for it.
+
+Asking a value of type different from the one in the FITS header will produce an error if the value
+is not convertible. A value `1.5` in the FITS header will produce an error if asked as an Integer.
+
+Note that the filters always use the primary header of the FITS files, no matter what is in the
+`hdu` setting. Using another HDU is not supported.
+
+### Filter Multiple target values
+
+Similar to Filter Single target value, but a list of possible values of the same type is given.
+One of them must hold to validate the filter.
+
+```yaml
+ESO DPR TYPE:  ["LAMP,WAVE", "WAVE,LAMP"]
+```
+
+### Filter Date range
+
+Defines a DateTime range. Inferior bound is inclusive and superior bound is exclusive.
+
+```yaml
+DATE-OBS:
+    min: 2022-04-01
+    max: 2022-04-13T12:24:10.003
+```
+Only files with 2022-04-01 <= file[DATE-OBS] < 2022-04-13T12:24:10.003 will be kept.
+
+Note that because of the limitations of the YAML library we use, if you use four digits after the
+second, the fourth one is truncated. So `2022-04-13T12:24:10.0039` is changed to
+`2022-04-13T12:24:10.003`.
+
+

--- a/src/AstronomicalDetectors.jl
+++ b/src/AstronomicalDetectors.jl
@@ -18,7 +18,7 @@ export
     CalibrationData,
     CalibrationInformation,
     scan_calibrations,
-    ReadCalibrationFiles
+    read_calibration_files_from_yaml
 
 using EasyFITS: FitsFile, FitsHeader, FitsImageHDU
 
@@ -27,9 +27,11 @@ using SimpleExpressions
 using ScientificDetectors
 using ScientificDetectors: CalibrationCategory
 
+include("Configs.jl")
+include("YAMLParsing.jl")
 
 include("ReadCalibration.jl")
-import .YAMLCalibrationFiles: ReadCalibrationFiles
+using .ReadCalibration: read_calibration_files_from_yaml
 
 struct CalibrationInformation
     path::String             # FITS file

--- a/src/Configs.jl
+++ b/src/Configs.jl
@@ -20,7 +20,7 @@ to permit mutual reference between `Config` and `ConfigCategory`
 abstract type AbsConfigCategory end
 
 """
-Describes a calibration by listing categories, along with the settings and filters to associate 
+Describes a calibration by listing categories, along with the settings and filters to associate
 FITS files.
 
 # Fields
@@ -114,7 +114,7 @@ Config() = Config(
         [".fits", ".fits.gz", ".fits.Z"], # suffixes,
         [],  # exclude_files
         true, # include_subdirectories
-        false) # follow_symbolic_links 
+        false) # follow_symbolic_links
 
 """Default `ConfigCategory` definition."""
 ConfigCategory(parent_config::Config, sources::Union{Symbol,Expr}) = ConfigCategory(

--- a/src/Configs.jl
+++ b/src/Configs.jl
@@ -1,0 +1,165 @@
+module Configs
+
+export Config, ConfigCategory,
+       ConfigFilter, ConfigFilterSingle, ConfigFilterMultiple, ConfigFilterRange, FilterValue,
+       challenge_filter
+
+using Dates
+
+const FilterValue = Union{String,Bool,Int64,Float64,Date,DateTime}
+
+"""
+Supertype for filters.
+"""
+abstract type ConfigFilter end
+
+"""
+the sole point of this abstract type is
+to permit mutual reference between `Config` and `ConfigCategory`
+"""
+abstract type AbsConfigCategory end
+
+"""
+Describes a calibration by listing categories, along with the settings and filters to associate 
+FITS files.
+
+# Fields
+- `filters`: list of the keyword filters. They will be checked on every candidate FITS file.
+- `categories`: list of `ConfigCategory`. Each will give a `CalibrationCategory`.
+- `title`: name of this config. Only informative for the end user.
+- `roi`: Region Of Interest on the detector. For full view use colons: `(:,:)`.
+- `exptime`: Name of the keyword containing the exposure time (mandatory information for the
+  calibration)
+- `dir`: Path of the folder where FITS files must be looked for. Can be absolute or relative.
+- `hdu`: identifier of the HeaderDataUnit to use in the FITS files. Can be an `Integer` and is thus
+  an index of the HDU, or can be a `String` and is therefore an `HDUNAME`. Default is `1`.
+- `files`: If non empty, it contains the strict list of paths of FITS files to use. Settings `dir`,
+  `suffixes`, `exclude_files`, `include_subdirectories` do not matter anymore. However, `filters`
+  are still checked on the files. Paths can be relative or absolute. If an empty list is given,
+  this parameter do nothing and the other keywords (`dir`, etc) are used. Default is empty list.
+- `suffixes`: Only FITS filenames that ends by at least one of the given suffixes are kept.
+  Default is `[".fits", ".fits.gz", ".fits.Z"]`.
+- `exclude_files`: Every FITS filename that contains at least one of the given `String` is unkept.
+  Default is an empty list.
+- `include_subdirectories`: If `true`, the subdirectories of `dir` are also recursively looked for
+  FITS files. Default is `true`.
+- `follow_symbolic_links`: If `true`, symbolic links are followed. Default is `false`.
+"""
+mutable struct Config
+    filters    ::Dict{String,ConfigFilter}
+    categories ::Dict{String,<:AbsConfigCategory} # will always be ConfigCategory
+    title      ::String
+    roi        ::NTuple{2,Union{Colon,StepRange{Int,Int}}}
+    exptime    ::String
+    dir        ::String
+    hdu           ::Union{Int,String}
+    files         ::Vector{String}
+    suffixes      ::Vector{String}
+    exclude_files ::Vector{String}
+    include_subdirectories ::Bool
+    follow_symbolic_links  ::Bool
+end
+
+"""
+Describes a category by a name, settings and keyword filters.
+
+A `ConfigCategory` belongs to a parent `Config` structure. The settings of a category are either
+defined or `nothing`. When a setting is `nothing`, the setting of the parent `Config` must be used.
+The field `sources` is an expression of the current sources in the files of this category, for
+example a category "FLAT" can have sources `flat + background + dark`. The setting `filters` lists
+the keyword filters for this category, but the filters of the parent `Config` will be checked too.
+If a `ConfigCategory` has a filter for a keyword and the parent config already has a filter for this
+keyword, the one of the `ConfigCategory` is used.
+"""
+mutable struct ConfigCategory <: AbsConfigCategory
+    parent_config ::Config
+    sources ::Union{Symbol,Expr}
+    filters ::Dict{String,ConfigFilter}
+    exptime ::Union{Nothing,String}
+    dir     ::Union{Nothing,String}
+    hdu     ::Union{Nothing,Int,String}
+    files         ::Union{Nothing,Vector{String}}
+    suffixes      ::Union{Nothing,Vector{String}}
+    exclude_files ::Union{Nothing,Vector{String}}
+    include_subdirectories ::Union{Nothing,Bool}
+    follow_symbolic_links  ::Union{Nothing,Bool}
+end
+
+"""
+Get a field of `ConfigCategory`, but when it is equal to nothing, use the field of parent `Config`.
+"""
+function Base.getproperty(category::ConfigCategory, s::Symbol)
+    f = getfield(category, s)
+    if f === nothing
+        if s in fieldnames(Config)
+            return getproperty(category.parent_config, s)
+        else
+            return nothing
+        end
+    else
+        return f
+    end
+end
+
+"""Default `Config` definition"""
+Config() = Config(
+        Dict(),   # filters
+        Dict{String,ConfigCategory}(), # categories
+        "",    # title
+        (:,:), # roi,
+        "",  # exptime
+        ".", # dir
+        1,   # hdu
+        [],  # files
+        [".fits", ".fits.gz", ".fits.Z"], # suffixes,
+        [],  # exclude_files
+        true, # include_subdirectories
+        false) # follow_symbolic_links 
+
+"""Default `ConfigCategory` definition."""
+ConfigCategory(parent_config::Config, sources::Union{Symbol,Expr}) = ConfigCategory(
+    parent_config, sources, Dict(), fill(nothing, 8)...)
+
+"""
+Filter that accepts only values equal to a single one.
+"""
+struct ConfigFilterSingle{T<:FilterValue} <: ConfigFilter
+    acceptedvalue ::T
+end
+
+"""
+Filter that accepts a value among a given list.
+"""
+struct ConfigFilterMultiple{T<:FilterValue} <: ConfigFilter
+    acceptedvalues ::Vector{T}
+end
+
+"""
+Filter that accepts a `Date` or `DateTime` between a given `DateTime` range, with minimum bound
+inclusive and maximum bound exclusive.
+"""
+struct ConfigFilterRange <: ConfigFilter
+    rangemin ::DateTime  # only date ranges accepted for now
+    rangemax ::DateTime
+end
+
+"""
+    `challenge_filter(configfilter, challenger) -> Bool
+
+Return `true` if the `challenger` value is valid with respect to the given filter.
+"""
+function challenge_filter(filter::ConfigFilterSingle{T}, challenger::T) ::Bool where {T}
+    challenger == filter.acceptedvalue
+end
+function challenge_filter(filter::ConfigFilterMultiple{T}, challenger::T) ::Bool where {T}
+    challenger in filter.acceptedvalues
+end
+function challenge_filter(filter::ConfigFilterRange, challenger::Union{Date,DateTime}) ::Bool
+    filter.rangemin ≤ challenger < filter.rangemax
+end
+
+function Base.eltype(::Type{ConfigFilterSingle{T}})   where {T} return T end
+function Base.eltype(::Type{ConfigFilterMultiple{T}}) where {T} return T end
+function Base.eltype(::Type{ConfigFilterRange})                 return DateTime end
+
+end # module Configs

--- a/src/YAMLParsing.jl
+++ b/src/YAMLParsing.jl
@@ -1,0 +1,284 @@
+module YAMLParsing
+
+export parse_yaml_file
+
+using YAML
+using Dates
+using BaseFITS
+using ..Configs
+
+"""
+    parse_setting_key(rawkey::String) -> Symbol
+    
+Change "YAML key style" with spaces, to "Julia Symbol style" with underscores. Modify some keys to
+assure retro-compatibility with old YAML files.
+
+This function do *not* check the validity of the key, this is done in functions
+[`parse_global_setting_value`](@ref) and [`parse_category_setting_value`](@ref).
+"""
+function parse_setting_key(rawkey::String) ::Symbol
+    if rawkey == "include subdirectory"
+        rawkey = "include subdirectories" # retro compat
+    end
+    return Symbol(replace(rawkey, ' ' => '_'))
+end
+
+"""
+    parse_global_setting_value(key::Symbol, rawvalue::Any) -> Any
+
+Check the validity of the `key`, parse the `rawvalue`, check its type.
+"""
+function parse_global_setting_value(key::Symbol, rawvalue::Any) ::Any
+    key in fieldnames(Config) || error("Unknown global setting key: $key.")
+    key in (:filters, :categories) && error("Forbidden global setting key: $key.")
+    value = parse_setting_value(key, rawvalue)
+    typeof(value) <: fieldtype(Config, key) || error(string(
+        "Value for global setting key \"$key\" has wrong type $(typeof(rawvalue)). ",
+        "It should have type $(fieldtype(Config, key))"))
+    return value
+end
+
+"""
+    parse_category_setting_value(key::Symbol, rawvalue::Any) -> Any
+
+Check the validity of the `key`, parse the `rawvalue`, check its type.
+"""
+function parse_category_setting_value(key::Symbol, rawvalue::Any) ::Any
+    key in fieldnames(ConfigCategory) || error("Unknown category setting key: $key.")
+    key in (:parent_config, :filters) && error("Forbidden category setting key: $key.")
+    value = parse_setting_value(key, rawvalue)
+    typeof(value) <: fieldtype(ConfigCategory, key) || error(string(
+        "Value for category setting key \"$key\" has wrong type $(typeof(rawvalue)). ",
+        "It should have type $(fieldtype(ConfigCategory, key))"))
+    return value
+end
+
+"""
+    parse_setting_value(key::Symbol, rawvalue::Any) -> Any
+
+Modify the `rawvalue`, depending on the `key`.
+
+Check the type for `:roi`, but for other keys the type is *not* checked, this is done in functions
+[`parse_global_setting_value`](@ref) and [`parse_category_setting_value`](@ref).
+- for `:files`, `:exclude_files`, and `:suffixes`: put `rawvalue` in a `Vector` if not
+  already the case.
+- for `:dir`, and `:files`: call `normpath` on all their path to ensure the separator is
+  compatible with the current Operating System.
+- for `:roi` and `:sources`: call parsing functions [`parse_setting_value_roi`](@ref) and
+  [`parse_setting_value_sources`](@ref).
+For `AbstractFloat` and `Integer` values, put them in "big boxes" `Float64` and `Int64`
+like BaseFITS do.
+"""
+function parse_setting_value(key::Symbol, rawvalue::Any) ::Any
+    # put in singleton vector if necessary
+    if key in (:files, :exclude_files, :suffixes) && !(rawvalue isa Vector)
+        rawvalue = [rawvalue]
+    end
+    
+    # convert numbers to the same types used in BaseFITS.
+    if rawvalue isa AbstractFloat          ; rawvalue = Float64(rawvalue) end
+    if rawvalue isa Union{Signed,Unsigned} ; rawvalue = Int64(rawvalue)   end
+                    # we don't want to convert Bool
+    
+    if     key == :dir     ; rawvalue = normpath.(rawvalue)
+    elseif key == :files   ; rawvalue = normpath.(rawvalue)
+    elseif key == :roi     ; rawvalue = parse_setting_value_roi(rawvalue)
+    elseif key == :sources ; rawvalue = parse_setting_value_sources(rawvalue)
+    end
+    return rawvalue
+end
+
+"""
+    parse_setting_value_sources(rawvalue::String) -> Union{Symbol,Expr}
+
+Parse `String` `:sources` value to a `Symbol` or an `Expr`.
+"""
+function parse_setting_value_sources(rawvalue::String) ::Union{Symbol,Expr}
+    sources = Meta.parse(rawvalue)
+end
+
+"""
+    parse_setting_value_roi(rawvalue::String) -> NTuple{2,Union{Colon,StepRange{Int,Int}}}
+
+Parse `String` `:roi` value to a couple of `Colon` or `StepRange`.
+
+A `Colon` means the full axe is used for Region Of Interest.
+
+# Examples
+```jldoctest
+julia> AstronomicalDetectors.YAMLParsing.parse_setting_value_roi(":,11:1014")
+(Colon(), 11:1:1014)
+```
+```jldoctest
+julia> typeof(AstronomicalDetectors.YAMLParsing.parse_setting_value_roi(":,11:1014"))
+Tuple{Colon, StepRange{Int64, Int64}}
+```
+"""
+function parse_setting_value_roi(rawvalue::String) ::NTuple{2,Union{Colon,StepRange{Int,Int}}}
+    roi = eval(Meta.parse(rawvalue))
+    roi isa Tuple    || error("Invalid type for setting roi: $(typeof(roi)).") 
+    length(roi) == 2 || error("Invalid number of ranges for setting roi: $(length(roi)).")
+    return map(roi) do range
+        if     range isa Colon         ; range
+        elseif range isa AbstractRange ; StepRange{Int,Int}(range)
+        else error("Invalid type for setting roi: $(typeof(roi)).") end
+    end
+end
+
+"""
+    parse_filter(key::String, rawvalue::Any) -> ConfigFilter
+
+Parse the `rawvalue` to a `ConfigFilter`.
+
+the subtype of `ConfigFilter` depends on the type of `rawvalue`. `key` is only used in
+warnings messages.
+"""
+function parse_filter(key::String, rawvalue::Any) ::ConfigFilter
+    if     rawvalue isa Dict   ; parse_filter_range(key, rawvalue)
+    elseif rawvalue isa Vector ; parse_filter_multiple(key, rawvalue)
+    else                         parse_filter_single(key, rawvalue)    end
+end
+
+"""
+    parse_filter_single(key::String, rawvalue::Any) -> ConfigFilterSingle
+
+Parse the `rawvalue` to a `ConfigFilterSingle`, provided the type of `rawvalue` belongs to 
+[`FilterValue`](@ref).
+"""
+function parse_filter_single(key::String, rawvalue::Any) ::ConfigFilterSingle
+    if rawvalue isa FilterValue ; return ConfigFilterSingle(rawvalue)
+    else error("For ConfigFilterSingle $key, wrong type $(typeof(rawvalue)).") end
+end
+
+"""
+    parse_filter_multiple(key::String, rawvalue::Any) -> ConfigFilterMultiple
+
+Parse the `rawvalue` to a `ConfigFilterMultiple`, provided the `eltype` of `rawvalue` belongs to 
+[`FilterValue`](@ref).
+
+`key` is only used in warnings messages.
+"""
+function parse_filter_multiple(key::String, rawvalue::Vector) ::ConfigFilterMultiple
+    if eltype(rawvalue) <: FilterValue ; return ConfigFilterMultiple(rawvalue)
+    else error("For ConfigFilterMultiple $key, wrong type Vector{$(eltype(rawvalue))}.") end
+end
+
+"""
+    parse_filter_range(key::String, rawvalue::Dict) -> ConfigFilterRange
+
+Parse the `rawvalue` to a `ConfigFilterMultiple`, provided `rawvalue` contains the corrects keys
+`min` and `max`.
+
+`key` is only used in warnings messages.
+"""
+function parse_filter_range(key::String, rawvalue::Dict) ::ConfigFilterRange
+    if (length(rawvalue) == 2
+        && haskey(rawvalue, "min")
+        && haskey(rawvalue, "max")
+        && rawvalue["min"] isa Union{Date,DateTime}
+        && rawvalue["max"] isa Union{Date,DateTime})
+       return ConfigFilterRange(rawvalue["min"], rawvalue["max"])
+    else
+        error(string("For ConfigFilterRange $key, wrong Dictionnary value $rawvalue. ",
+                     "Only date ranges with keys \"min\" and \"max\" are accepted."))
+    end
+end
+
+"""
+    isa_filter_key(rawkey::String) -> Bool
+
+Return `true` if `rawkey` is considered a valid FITS keyword.
+"""
+function isa_filter_key(rawkey::String) ::Bool
+    ! (BaseFITS.Parser.try_parse_keyword(rawkey) isa Char)
+end
+
+"""
+    parse_category(parent_config::Config, name, rawvalue) -> ConfigCategory
+
+Parse `rawvalue` as a `ConfigCategory`. Parse its settings and filters.
+"""
+function parse_category(parent_config::Config, name::String, rawvalue::Any) ::ConfigCategory
+
+    rawvalue isa Dict{String,Any} || error("Category $name has wrong type: $(typeof(rawvalue)).")
+
+    haskey(rawvalue, "sources") || error("Category $name misses the key \"sources\".")
+    sources = parse_setting_value_sources(rawvalue["sources"])
+
+    category = ConfigCategory(parent_config, sources)
+
+    for (rawkey, rawvalue) in rawvalue
+        rawkey == "sources" && continue # already parsed
+    
+        if isa_filter_key(rawkey)
+            category.filters[rawkey] = parse_filter(rawkey, rawvalue)
+        else
+            key = parse_setting_key(rawkey)
+            setproperty!(category, key, parse_category_setting_value(key, rawvalue))
+        end
+    end
+    return category
+end
+
+"""
+    parse_config(yaml::Dict{String,Any}) -> Config
+
+Parse a `Dict` coming from a YAML file to a `Config`. Parse its settings, filters, and categories.
+
+The YAML must have been loaded with the option `dicttype=Dict{String,Any}` so that the key of
+the dict has type `String`.
+"""
+function parse_config(yaml::Dict{String,Any}) ::Config
+
+    haskey(yaml, "categories") || error("Mandatory \"categories\" section not found.")
+    rawcategories = yaml["categories"]
+    
+    rawcategories isa Dict{String,Any} || error(
+        "Section \"categories\" has wrong type: $(typeof(rawcategories)).")
+        
+    isempty(rawcategories) && error("Section \"categories\" must not be empty.")
+    
+    config = Config()
+   
+    # categories
+    for (name, rawvalue) in rawcategories
+        haskey(config.categories, name) && error("Two definitions for category $name.")
+        config.categories[name] = parse_category(config, name, rawvalue)
+    end
+    
+    # settings and filters
+    for (rawkey,rawvalue) in yaml
+        rawkey == "categories" && continue # already parsed
+            
+        if isa_filter_key(rawkey)
+            config.filters[rawkey] = parse_filter(rawkey, rawvalue)
+        else
+            key = parse_setting_key(rawkey)
+            setproperty!(config, key, parse_global_setting_value(key, rawvalue))
+        end
+    end
+    
+    # check that exptime is defined for every category
+    if isempty(config.exptime)
+        for (name,category) in categories
+            cat.exptime === nothing && error(
+                "Category $name has setting \"exptime\" undefined while global ",
+                "setting \"exptime\" is empty. You must define at least one.")
+        end
+    end
+    
+    return config
+end
+
+"""
+    parse_yaml_file(filepath) -> Config
+    
+Parse YAML file as a `Config`.
+"""
+function parse_yaml_file(filepath::AbstractString) ::Config
+    # we set the `dicttype` parameter: mandatory for `parse_config` to work
+    yaml = YAML.load_file(filepath ; dicttype=Dict{String,Any})
+    return parse_config(yaml)
+end
+
+end # module YAMLParsing

--- a/src/YAMLParsing.jl
+++ b/src/YAMLParsing.jl
@@ -9,7 +9,7 @@ using ..Configs
 
 """
     parse_setting_key(rawkey::String) -> Symbol
-    
+
 Change "YAML key style" with spaces, to "Julia Symbol style" with underscores. Modify some keys to
 assure retro-compatibility with old YAML files.
 
@@ -74,12 +74,12 @@ function parse_setting_value(key::Symbol, rawvalue::Any) ::Any
     if key in (:files, :exclude_files, :suffixes) && !(rawvalue isa Vector)
         rawvalue = [rawvalue]
     end
-    
+
     # convert numbers to the same types used in BaseFITS.
     if rawvalue isa AbstractFloat          ; rawvalue = Float64(rawvalue) end
     if rawvalue isa Union{Signed,Unsigned} ; rawvalue = Int64(rawvalue)   end
                     # we don't want to convert Bool
-    
+
     if     key == :dir     ; rawvalue = normpath.(rawvalue)
     elseif key == :files   ; rawvalue = normpath.(rawvalue)
     elseif key == :roi     ; rawvalue = parse_setting_value_roi(rawvalue)
@@ -116,7 +116,7 @@ Tuple{Colon, StepRange{Int64, Int64}}
 """
 function parse_setting_value_roi(rawvalue::String) ::NTuple{2,Union{Colon,StepRange{Int,Int}}}
     roi = eval(Meta.parse(rawvalue))
-    roi isa Tuple    || error("Invalid type for setting roi: $(typeof(roi)).") 
+    roi isa Tuple    || error("Invalid type for setting roi: $(typeof(roi)).")
     length(roi) == 2 || error("Invalid number of ranges for setting roi: $(length(roi)).")
     return map(roi) do range
         if     range isa Colon         ; range
@@ -142,7 +142,7 @@ end
 """
     parse_filter_single(key::String, rawvalue::Any) -> ConfigFilterSingle
 
-Parse the `rawvalue` to a `ConfigFilterSingle`, provided the type of `rawvalue` belongs to 
+Parse the `rawvalue` to a `ConfigFilterSingle`, provided the type of `rawvalue` belongs to
 [`FilterValue`](@ref).
 """
 function parse_filter_single(key::String, rawvalue::Any) ::ConfigFilterSingle
@@ -153,7 +153,7 @@ end
 """
     parse_filter_multiple(key::String, rawvalue::Any) -> ConfigFilterMultiple
 
-Parse the `rawvalue` to a `ConfigFilterMultiple`, provided the `eltype` of `rawvalue` belongs to 
+Parse the `rawvalue` to a `ConfigFilterMultiple`, provided the `eltype` of `rawvalue` belongs to
 [`FilterValue`](@ref).
 
 `key` is only used in warnings messages.
@@ -209,7 +209,7 @@ function parse_category(parent_config::Config, name::String, rawvalue::Any) ::Co
 
     for (rawkey, rawvalue) in rawvalue
         rawkey == "sources" && continue # already parsed
-    
+
         if isa_filter_key(rawkey)
             category.filters[rawkey] = parse_filter(rawkey, rawvalue)
         else
@@ -232,24 +232,24 @@ function parse_config(yaml::Dict{String,Any}) ::Config
 
     haskey(yaml, "categories") || error("Mandatory \"categories\" section not found.")
     rawcategories = yaml["categories"]
-    
+
     rawcategories isa Dict{String,Any} || error(
         "Section \"categories\" has wrong type: $(typeof(rawcategories)).")
-        
+
     isempty(rawcategories) && error("Section \"categories\" must not be empty.")
-    
+
     config = Config()
-   
+
     # categories
     for (name, rawvalue) in rawcategories
         haskey(config.categories, name) && error("Two definitions for category $name.")
         config.categories[name] = parse_category(config, name, rawvalue)
     end
-    
+
     # settings and filters
     for (rawkey,rawvalue) in yaml
         rawkey == "categories" && continue # already parsed
-            
+
         if isa_filter_key(rawkey)
             config.filters[rawkey] = parse_filter(rawkey, rawvalue)
         else
@@ -257,7 +257,7 @@ function parse_config(yaml::Dict{String,Any}) ::Config
             setproperty!(config, key, parse_global_setting_value(key, rawvalue))
         end
     end
-    
+
     # check that exptime is defined for every category
     if isempty(config.exptime)
         for (name,category) in categories
@@ -266,13 +266,13 @@ function parse_config(yaml::Dict{String,Any}) ::Config
                 "setting \"exptime\" is empty. You must define at least one.")
         end
     end
-    
+
     return config
 end
 
 """
     parse_yaml_file(filepath) -> Config
-    
+
 Parse YAML file as a `Config`.
 """
 function parse_yaml_file(filepath::AbstractString) ::Config

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
-using AstronomicalDetectors
 using Test
 using EasyFITS
 using Dates
-using AstronomicalDetectors.YAMLCalibrationFiles
-using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
+using AstronomicalDetectors
+using AstronomicalDetectors.Configs
+using AstronomicalDetectors.YAMLParsing:
+    parse_setting_key, parse_global_setting_value, parse_category_setting_value,
+    parse_setting_value, parse_setting_value_sources, parse_setting_value_roi,
+    parse_filter, parse_filter_single, parse_filter_multiple, parse_filter_range,
+    isa_filter_key, parse_category, parse_yaml_file
+using AstronomicalDetectors.ReadCalibration:
+    parse_datetime_like_yaml, find_filepaths_by_category, gather_filters_keywords,
+    gather_files_infos, challenge_file, find_and_filter_files_by_category,
+    read_calibration_files_from_yaml
 
 @testset "AstronomicalDetectors.jl" begin
     # Write your tests here.
@@ -79,151 +87,402 @@ using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
     end
 end
 
-@testset "ReadCalibration.jl" begin
-
-    @testset "filtercat single value" begin
-        hdr = FitsHeader(
-            "QUESTION" => "What is the answer?",
-            "ANSWER" => 42,
-            "CLEVER" => false,
-            "HALF" => 1.5,
-            "VOID" => nothing,
-            "ESO INFORMATIVE MESSAGE" => "I like my keyword names to be long")
-        dict = Dict("file1" => hdr)
-        @test !isempty(filtercat(dict, "QUESTION", "What is the answer?"))
-        @test !isempty(filtercat(dict, "ANSWER", 42))
-        @test !isempty(filtercat(dict, "CLEVER", false))
-        @test !isempty(filtercat(dict, "HALF", 1.5e0))
-        @test !isempty(filtercat(dict, "HALF", 1.5f0))
-        @test !isempty(filtercat(dict, "ANSWER", Int8(42)))
-        @test !isempty(filtercat(dict, "ANSWER", UInt64(42)))
-        warnmsg = "card type Float64 is != from target value type String in file file1"
-        @test_warn warnmsg filtercat(dict, "HALF", "1.5")
-        errormsg = "Complex values not yet implemented"
-        @test_throws ErrorException(errormsg) filtercat(dict, "HALF", 1.5+0im)
-        warnmsg = "card type Float64 is != from target value type Int64 in file file1"
-        @test_warn warnmsg filtercat(dict, "HALF", 1)
-        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
-        @test_warn warnmsg filtercat(dict, "ANSWER", 42e0)
-        errormsg = "unsupported target value type Nothing"
-        @test_throws ErrorException(errormsg) filtercat(dict, "VOID", nothing)
-        warnmsg = "card type Nothing is != from target value type String in file file1"
-        @test_warn warnmsg filtercat(dict, "VOID", "something")
-        @test !isempty(filtercat(dict, "ESO INFORMATIVE MESSAGE",
-                                       "I like my keyword names to be long"))
+@testset "Configs" begin
+    @testset "config and categories and filters creation" begin
+        @test_nowarn Config()
+        @test_nowarn ConfigCategory(Config(), :mysource)
+        @test_nowarn ConfigFilterSingle(42)
+        @test_nowarn ConfigFilterSingle(33.33)
+        @test_nowarn ConfigFilterSingle("abc")
+        @test_nowarn ConfigFilterSingle(true)
+        @test_nowarn ConfigFilterSingle(Date(2000,1,1))
+        @test_nowarn ConfigFilterMultiple([42, 42])
+        @test_nowarn ConfigFilterMultiple([33.33, 44.44])
+        @test_nowarn ConfigFilterMultiple(["abc", "def"])
+        @test_nowarn ConfigFilterMultiple([true, false])
+        @test_nowarn ConfigFilterMultiple([Date(2000,1,1), DateTime(2000,1,2)])
+        @test_nowarn ConfigFilterRange(Date(2000,1,1), Date(2000,1,3))
     end
-
-    @testset "filtercat several value" begin
-        hdr = FitsHeader("GOOD" => 2)
-        dict = Dict("file1" => hdr)
-        @test !isempty(filtercat(dict, "GOOD", [1, 2]))
-        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
-        @test_warn warnmsg filtercat(dict, "GOOD", [1.0, 2.0])
-        errormsg = "eltype Any of the Vector target value is not supported"
-        @test_throws ErrorException(errormsg) filtercat(dict, "GOOD", [1, "2"])
+    @testset "getproperty and inheritance" begin
+        config = Config()
+        config.exptime = "EXPTIME"
+        category = ConfigCategory(config, :mysource)
+        @test category.exptime == "EXPTIME"
+        category.exptime = "TIMEEXP"
+        @test category.exptime == "TIMEEXP"
+        category.exptime = nothing
+        @test category.exptime == "EXPTIME"
     end
-
-    @testset "filtercat date range" begin
-        # date range
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2024-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
-
-        # date range with fitsheader date with fourth millisecond in FITS file
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.1234"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2024-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
-
-        # date range exclude
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2023-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test isempty(filelist2)
-
-        # date range include
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2022-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2023-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
-
-        # yaml file, with a test with fourth millisecond
-        mktemp()        do pathyaml,fileio
-        mktempdir()     do pathdir
-        mktemp(pathdir) do pathfits,fileio
-
-            hdr = FitsHeader("DATE" => "2023-11-20T08:00:10.1234", "TIME" => 1.1)
-            yaml = """
-                   suffixes: [$pathfits]
-                   exptime: "TIME"
-                   categories:
-                     TOTO:
-                       DATE:
-                           min: 2022-11-20T08:00:10.1234
-                           max: 2024-11-20T08:00:10.1234
-                       sources: toto
-                   """
-            write(pathyaml, yaml)
-            writefits!(pathfits, hdr, Int[0 0 ; 0 0])
-            ReadCalibrationFiles(pathyaml; dir=pathdir)
-
-        end end end
+    @testset "challenge_filter" begin
+        @test challenge_filter(ConfigFilterSingle(33.33), 33.33)
+        @test ! challenge_filter(ConfigFilterSingle(33.33), 44.44)
+        @test challenge_filter(ConfigFilterMultiple([33.33, 44.44]), 33.33)
+        @test challenge_filter(ConfigFilterMultiple([33.33]), 33.33)
+        @test ! challenge_filter(ConfigFilterMultiple([33.33, 44.44]), 55.55)
+        @test challenge_filter(ConfigFilterRange(Date(2000,1,1), Date(2000,1,3)), Date(2000,1,1))
+        @test challenge_filter(ConfigFilterRange(Date(2000,1,1), Date(2000,1,3)), Date(2000,1,2))
+        @test ! challenge_filter(ConfigFilterRange(Date(2000,1,1), Date(2000,1,3)), Date(2000,1,3))
     end
-
-    @testset "ReadCalibrationFiles with example_from_the_doc.yml" begin
-        initialdir = pwd()
-        try
-            mktempdir() do pathdir
-
-                cd(pathdir)
-
-                # build directory structure like in the example
-                mkdir("alice")
-                mkdir("alice/calibration-files")
-                mkdir("alice/calibration-files/subfolder")
-                mkdir("alice/wave-calibration-folder")
-
-                hdr1 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05",
-                                  "ESO INS COMB IFLT" => "BB_H", "ESO DPR TYPE" => "FLAT,LAMP")
-                writefits!("alice/calibration-files/file1.fits", hdr1, [1;;])
-
-                hdr2 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "DARK")
-                writefits!("alice/calibration-files/subfolder/file2.fits", hdr2, [1;;])
-
-                hdr3 = FitsHeader("SPECIAL DIT KEYWORD" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "LAMP,WAVE")
-                writefits!("alice/wave-calibration-folder/file3.fits", hdr3, [1;;])
-
-                # put one in a wrong folder to see if it is correctly excluded
-                writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
-
-                data = ReadCalibrationFiles(initialdir * "/test/example_from_the_doc.yml")
-
-                @test "FLAT"       in keys(data.cat_index)
-                @test "BACKGROUND" in keys(data.cat_index)
-                @test "WAVE"       in keys(data.cat_index)
-                @test "flat"       in keys(data.src_index)
-                @test "background" in keys(data.src_index)
-                @test "wave"       in keys(data.src_index)
-                @test data.stat[data.stat_index[("FLAT",1)      ]].n == 1
-                @test data.stat[data.stat_index[("BACKGROUND",1)]].n == 1
-                @test data.stat[data.stat_index[("WAVE",1)      ]].n == 1
-            end
-        finally cd(initialdir) end
+    @testset "eltype" begin
+        @test eltype(ConfigFilterSingle(3333e-2)) == Float64
+        @test eltype(ConfigFilterMultiple([3333e-2])) == Float64
+        @test eltype(ConfigFilterRange(Date(2000,1,1),Date(2000,1,2))) == DateTime
     end
 end
+
+@testset "YAMLParsing" begin
+    @testset "parse_setting_key" begin
+        @test parse_setting_key("exclude files") == :exclude_files
+    end
+    @testset "parse_global_setting_value" begin
+        @test_throws ErrorException parse_global_setting_value(:MDR, nothing)
+        @test_throws ErrorException parse_global_setting_value(:filters, nothing)
+        @test_throws ErrorException parse_global_setting_value(:exptime, nothing)
+        @test parse_global_setting_value(:exptime, "EXPTIME") == "EXPTIME"
+    end
+    @testset "parse_category_setting_value" begin
+        @test_throws ErrorException parse_category_setting_value(:MDR, nothing)
+        @test_throws ErrorException parse_category_setting_value(:exptime, 33.33)
+        @test parse_category_setting_value(:exptime, nothing) == nothing
+        @test parse_category_setting_value(:exptime, "EXPTIME") == "EXPTIME"
+    end
+    @testset "parse_setting_value" begin
+        @test parse_setting_value(:suffixes, ".fits") == [".fits"]
+        @test parse_setting_value(:suffixes, [".fits", ".fits.Z"]) == [".fits", ".fits.Z"]
+        @test parse_setting_value(:dir, "././toto/../toto") == "toto"
+        @test parse_setting_value(:dir, "/toto") == string(Base.Filesystem.path_separator, "toto")
+        @test parse_setting_value(:exptime, "EXPTIME") == "EXPTIME"
+    end
+    @testset "parse_setting_value_sources" begin
+        @test parse_setting_value_sources("toto") == :toto
+        @test parse_setting_value_sources("toto + tata") == :(toto + tata)
+        @test parse_setting_value_sources("toto + tata + tutu") == :(toto + tata + tutu)
+        @test parse_setting_value_sources("0.5toto") == :(0.5toto)
+    end
+    @testset "parse_setting_value_roi" begin
+        @test parse_setting_value_roi("(:,:)"      ) == (Colon(), Colon())
+        @test parse_setting_value_roi(":,:"        ) == (Colon(), Colon())
+        @test parse_setting_value_roi("  :,   :   ") == (Colon(), Colon())
+        @test parse_setting_value_roi("(((:,:,)))" ) == (Colon(), Colon())
+        @test parse_setting_value_roi("(1:10,2:20)") ==
+            (StepRange{Int,Int}(1,1,10), StepRange{Int,Int}(2,1,20))
+        @test parse_setting_value_roi("(1:2:10,2:3:20)") ==
+            (StepRange{Int,Int}(1,2,10), StepRange{Int,Int}(2,3,20))
+        @test parse_setting_value_roi("(:,1:10)"   ) == (Colon(), StepRange{Int,Int}(1,1,10))
+        @test parse_setting_value_roi("(1:10,:)"   ) == (StepRange{Int,Int}(1,1,10),Colon())
+    end
+    @testset "parse_filter" begin
+        @test parse_filter("TOTO", 42) == ConfigFilterSingle(42)
+        @test parse_filter("TOTO", [42]).acceptedvalues == ConfigFilterMultiple([42]).acceptedvalues
+        @test parse_filter("TOTO", Dict{String,Any}("min" => Date(1,1,1), "max" => Date(1,1,2))) ==
+            ConfigFilterRange(Date(1,1,1), Date(1,1,2))
+    end
+    @testset "parse_filter_single" begin
+        @test parse_filter_single("TOTO", 42) == ConfigFilterSingle(42)
+        @test_throws ErrorException parse_filter_single("TOTO", (42,42))
+    end
+    @testset "parse_filter_multiple" begin
+        @test parse_filter_multiple("TOTO", [42]).acceptedvalues ==
+            ConfigFilterMultiple([42]).acceptedvalues
+        @test_throws ErrorException parse_filter_multiple("TOTO", [(42,42)])
+    end
+    @testset "parse_filter_range" begin
+        @test parse_filter_range("TOTO",
+            Dict{String,Any}("min" => Date(1,1,1), "max" => Date(1,1,2))) ==
+            ConfigFilterRange(Date(1,1,1), Date(1,1,2))
+        @test_throws MethodError parse_filter_range("TOTO", 42)
+        @test_throws ErrorException parse_filter_range("TOTO",
+            Dict{String,Any}("min" => Date(1,1,1), "max" => Date(1,1,2), "MDR" => true))
+        @test_throws ErrorException parse_filter_range("TOTO",
+            Dict{String,Any}("MIN" => Date(1,1,1), "max" => Date(1,1,2)))
+        @test_throws ErrorException parse_filter_range("TOTO",
+            Dict{String,Any}("min" => 42, "max" => Date(1,1,2)))
+    end
+    @testset "isa_filter_key" begin
+        @test isa_filter_key("TOTO")
+        @test isa_filter_key("")
+        @test isa_filter_key("123")
+        @test isa_filter_key("TOTO123")
+        @test isa_filter_key("___TOTO___3244")
+        @test isa_filter_key("TOTO")
+        @test ! isa_filter_key("tOTO")
+    end
+    @testset "parse_category (incomplete test set)" begin
+        @test_throws ErrorException parse_category(Config(), "TOTO", 42)
+        @test_throws ErrorException parse_category(Config(), "TOTO", Dict{String,Any}())
+    end
+    @testset "parse zoo/ folder" begin
+        zoo = isdir("zoo/") ? "zoo/" :
+              isfile("../zoo/") ? "../zoo/" :
+              error("Cannot find zoo/ folder. Are you in the project root folder ?")
+        for yamlpath in filter(endswith(".yaml"), readdir(zoo))
+            @test_nowarn parse_yaml_file(joinpath(zoo, yamlpath))
+        end
+    end
+end
+
+@testset "ReadCalibration.parse_datetime_like_yaml" begin
+    @test parse_datetime_like_yaml("2023-05-30T15:27:19.449") ==
+        DateTime(2023,5,30,15,27,19,449)
+    @test parse_datetime_like_yaml("2023-05-30T15:27:19.4499") ==
+        DateTime(2023,5,30,15,27,19,449)
+    @test parse_datetime_like_yaml("MDR") == DateTime(0,1,1)
+end
+    
+#TODO: test follow_symbolic_links, which seems to concern only symbolic link to folders
+@testset "ReadCalibration.find_filepaths_by_category" begin
+    mktempdir() do tmpdir
+    
+        rootdir    = joinpath(tmpdir, "rootdir")
+        altrootdir = joinpath(tmpdir, "altrootdir")
+        subrootdir = joinpath(rootdir, "subrootdir")
+        
+        flatpath1 = joinpath(rootdir,    "flat1.fits")
+        flatpath2 = joinpath(rootdir,    "flat2.fitsyfits") # bad extension
+        flatpath3 = joinpath(rootdir,    "useless-flat3.fits") # excluded by `exclude_files`
+        flatpath4 = joinpath(subrootdir, "flat4.fits")      # in sub root dir
+        
+        backname1 = "back1.fits"
+        # will be adressed by relative path.
+        backpath1 = joinpath(rootdir, backname1)
+        backpath2 = joinpath(altrootdir, "back2.fits") # in altrootdir, will be adressed by `files`
+        
+        darkpath1 = joinpath(altrootdir, "dark1.fits") # will be found by setting `dir`
+        # bad extension but ok since `suffixes` is different for category DARK
+        darkpath2 = joinpath(altrootdir, "dark2.fitsyfits")
+        
+        # [rootdir]
+        # |-- flat1.fits
+        # |-- flat2.fitsyfits
+        # |-- useless-flat3.fits
+        # |-- back1.fits
+        # |-- [subrootdir]
+        #     |-- flat4.fits
+        # [altrootdir]
+        # |-- back2.fits
+        # |-- dark1.fits
+        # |-- dark2.fitsyfits
+        
+        mkdir(rootdir)
+        mkdir(subrootdir)
+        mkdir(altrootdir)
+        writefits!(flatpath1, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"), [111;;])
+        writefits!(flatpath2, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"), [112;;])
+        writefits!(flatpath3, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"), [113;;])
+        writefits!(flatpath4, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"), [114;;])
+        writefits!(backpath1,  FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "BACK"), [11 ;;])
+        writefits!(backpath2,  FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "BACK"), [12 ;;])
+        writefits!(darkpath1,  FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "DARK"), [1  ;;])
+        writefits!(darkpath2,  FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "DARK"), [2  ;;])
+    
+        config = Config()
+        config.exptime = "EXPTIME"
+        config.exclude_files = ["useless"]
+    
+        config.categories["FLAT"] = ConfigCategory(config, :(flat + back + dark))
+        config.categories["FLAT"].filters["CALIBTYPE"] = ConfigFilterSingle("FLAT")
+    
+        config.categories["BACK"] = ConfigCategory(config, :(back + dark))
+        config.categories["BACK"].filters["CALIBTYPE"] = ConfigFilterSingle("BACK")
+        config.categories["BACK"].files = [backname1, backpath2] # strict file list
+                                           # first path is relative and will become absolute 
+        config.categories["BACK"].suffixes = [] # no suffixes accepted but it will has no effect
+                                                # since we use the setting `files`
+    
+        config.categories["DARK"] = ConfigCategory(config, :dark)
+        config.categories["DARK"].filters["CALIBTYPE"] = ConfigFilterSingle("DARK")
+        config.categories["DARK"].dir = altrootdir # search for fits in `altrootdir` folder
+        config.categories["DARK"].suffixes = [".fitsyfits" ; config.suffixes]
+                                             # another suffix accepted
+    
+        local filesbycats
+        
+        @test_nowarn filesbycats = find_filepaths_by_category(config ; basedir=rootdir)
+        
+        # flatpath1 present because in root dir
+        # flatpath2 absent because bad extension
+        # flatpath3 absent because contain substring "useless"
+        # flatpath4 present because in sub root dir
+        # backpath1 present because in root dir and filters are not applied yet in this step
+        @test Set(filesbycats["FLAT"]) ==
+            Set([flatpath1, flatpath4, backpath1])
+        
+        # backpath1 present because in the setting `files`
+        # backpath2 present because backname1 has been made an absolute path
+        # all other files absent because not in setting `files`
+        @test Set(filesbycats["BACK"]) == Set([backpath1, backpath2])
+        
+        # backpath2 and darkpath1 present because in altrootdir
+        # darkpath2 present because suffix "fitsyfits" allowed in category DARK
+        @test Set(filesbycats["DARK"]) == Set([backpath2, darkpath1, darkpath2])
+    end
+end
+
+@testset "ReadCalibration.gather_filters_keywords" begin
+    config = Config()
+    config.filters["TOTO"] = ConfigFilterSingle(42)
+    config.filters["TATA"] = ConfigFilterMultiple([3333e-2, 4444e-2])
+    config.filters["TUTU"] = ConfigFilterRange(Date(0,1,1), Date(0,1,2))
+    config.categories["CAT"] = ConfigCategory(config, :cat)
+    config.categories["CAT"].filters["TITI"] = ConfigFilterSingle(true)
+    config.categories["CAT"].filters["TOTO"] = ConfigFilterSingle(43)
+    @test gather_filters_keywords(config) == Dict{String,Type}(
+        "TOTO" => Int, "TATA" => Float64, "TUTU" => DateTime, "TITI" => Bool)
+    config.categories["CAT"].filters["TOTO"] = ConfigFilterSingle("WRONG")
+    @test_warn "Redefinition of filter keyword's type" gather_filters_keywords(config)
+end
+
+@testset "ReadCalibration.gather_files_infos" begin
+    filters_keywords = Dict{String,Type}(
+        "EXPTIME" => Float64, "DATE" => DateTime, "VERY LONG KKKEEEYYYWWWOOORRRDDDD" => Bool)
+    mktempdir() do tmpdir
+        
+        filepath1 = joinpath(tmpdir, "file1.fits")
+        filepath2 = joinpath(tmpdir, "file2.fits")
+        filepaths = Set([filepath1, filepath2])
+        hdr1 = FitsHeader(
+            "EXPTIME" => 3333e-2, "DATE" => DateTime(0,1,1),
+            "VERY LONG KKKEEEYYYWWWOOORRRDDDD" => true)
+        hdr2 = FitsHeader("EXPTIME" => 3333f-2)
+        writefits!(filepath1, hdr1, [1;;])
+        writefits!(filepath2, hdr2, [1;;])
+
+        infos = gather_files_infos(filepaths, filters_keywords)
+        
+        @test typeof(infos[filepath1]["EXPTIME"]) == filters_keywords["EXPTIME"]
+        @test typeof(infos[filepath1]["DATE"])    == filters_keywords["DATE"]
+        @test typeof(infos[filepath1]["VERY LONG KKKEEEYYYWWWOOORRRDDDD"]) ==
+            filters_keywords["VERY LONG KKKEEEYYYWWWOOORRRDDDD"]
+        @test infos[filepath1]["EXPTIME"]         == hdr1["EXPTIME"].float
+        @test infos[filepath1]["DATE"]            == hdr1["DATE"].value(DateTime)
+        @test infos[filepath1]["VERY LONG KKKEEEYYYWWWOOORRRDDDD"] ==
+            hdr1["VERY LONG KKKEEEYYYWWWOOORRRDDDD"].logical
+        
+        @test typeof(infos[filepath2]["EXPTIME"])  == filters_keywords["EXPTIME"]
+        @test typeof(infos[filepath2]["DATE"])     == Missing
+        @test typeof(infos[filepath2]["VERY LONG KKKEEEYYYWWWOOORRRDDDD"]) == Missing
+        # file2 contains EXPTIME as a Float32 so we lost precision. not our fault!
+        @test Float32(infos[filepath2]["EXPTIME"]) == hdr2["EXPTIME"].float
+        @test ismissing(infos[filepath2]["DATE"])
+        @test ismissing(infos[filepath2]["VERY LONG KKKEEEYYYWWWOOORRRDDDD"])
+    end
+end
+
+@testset "ReadCalibration.challenge_file" begin
+    filters = Dict{String,ConfigFilter}()
+    filters["TOTO"] = ConfigFilterSingle(42)
+    filters["TATA"] = ConfigFilterSingle(33.33)
+    filters["TITI"] = ConfigFilterSingle(true)
+    filters["TUTU"] = ConfigFilterSingle("abc")
+    filters["TUTUTU"] = ConfigFilterMultiple(["abc", "def"])
+    filters["TETETE"] = ConfigFilterRange(Date(0,1,1), Date(0,1,3))
+    # correct infos
+    files_infos1 = Dict{String,Any}()
+    files_infos1["TOTO"] = filters["TOTO"].acceptedvalue
+    files_infos1["TATA"] = filters["TATA"].acceptedvalue
+    files_infos1["TITI"] = filters["TITI"].acceptedvalue
+    files_infos1["TUTU"] = filters["TUTU"].acceptedvalue
+    files_infos1["TUTUTU"] = filters["TUTUTU"].acceptedvalues[1]
+    files_infos1["TETETE"] = filters["TETETE"].rangemin
+    @test first(challenge_file(filters, files_infos1))
+    
+    # make incorrect infos
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TOTO"] = filters["TOTO"].acceptedvalue + 1
+    @test challenge_file(filters, files_infos2) == (false, "TOTO")
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TATA"] = filters["TATA"].acceptedvalue + 0.000001
+    @test challenge_file(filters, files_infos2) == (false, "TATA")
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TITI"] = ! filters["TITI"].acceptedvalue
+    @test challenge_file(filters, files_infos2) == (false, "TITI")
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TUTU"] = filters["TUTU"].acceptedvalue * 'd'
+    @test challenge_file(filters, files_infos2) == (false, "TUTU")
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TUTUTU"] = reduce(*, filters["TUTUTU"].acceptedvalues)
+    @test challenge_file(filters, files_infos2) == (false, "TUTUTU")
+    
+    files_infos2 = copy(files_infos1)
+    files_infos2["TETETE"] = filters["TETETE"].rangemax
+    @test challenge_file(filters, files_infos2) == (false, "TETETE")
+end
+
+@testset "ReadCalibration.read_calibration_files_from_yaml" begin
+    # this also serves as test for CalibrationData and find_and_filter_files_by_category
+    
+    yamldata =
+"""
+exptime: EXPTIME
+categories:
+    FLAT:
+        sources: flat + back
+        CALIBTYPE: FLAT
+    BACK:
+        sources: back
+        CALIBTYPE: BACK
+        hdu: 2
+"""
+    mktemp() do yamlpath,yamlfileio
+    mktempdir() do tmpdir
+    
+        write(yamlpath, yamldata)
+    
+        rootpath = joinpath(tmpdir, "rootdir")
+        subpath  = joinpath(rootpath, "subdir")
+        mkdir(rootpath)
+        mkdir(subpath)
+        
+        flatpath1 = joinpath(subpath, "flat1.fits")
+        flatpath2 = joinpath(subpath, "flat2.fits")
+        
+        flatpath3 = joinpath(rootpath, "flat3.fits")
+        
+        backpath1 = joinpath(rootpath, "back1.fits")
+        backpath2 = joinpath(rootpath, "back2.fits")
+        
+        writefits!(flatpath1, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"),
+                              [101 ; 101 ;; 101 ; 101])
+        writefits!(flatpath2, FitsHeader("EXPTIME" => 10e0, "CALIBTYPE" => "FLAT"),
+                              [1010 ; 1010 ;; 1010 ; 1010])
+        writefits!(flatpath3, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "FLAT"),
+                              [103 ; 103 ;; 103 ; 103])
+        
+        writefits!(backpath1, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "BACK"),
+                              [0;;],
+                              FitsHeader(),
+                              [1 ; 1 ;; 1 ; 1])
+        writefits!(backpath2, FitsHeader("EXPTIME" => 1e0, "CALIBTYPE" => "BACK"),
+                              [0;;],
+                              FitsHeader(),
+                              [3 ; 3 ;; 3 ; 3])
+
+        calib = read_calibration_files_from_yaml(yamlpath ; basedir=rootpath)
+        @test Set(keys(calib.src_index)) == Set(["flat", "back"])
+        @test Set(keys(calib.cat_index)) == Set(["FLAT", "BACK"])
+        @test calib.stat[calib.stat_index[("FLAT",1e0)]].n == 2
+        @test calib.stat[calib.stat_index[("FLAT",1e0)]].s[1] == [102 ; 102 ;; 102 ; 102]
+        @test calib.stat[calib.stat_index[("FLAT",10e0)]].n == 1
+        @test calib.stat[calib.stat_index[("FLAT",10e0)]].s[1] == [1010 ; 1010 ;; 1010 ; 1010]
+        @test calib.stat[calib.stat_index[("BACK",1e0)]].n == 2
+        @test calib.stat[calib.stat_index[("BACK",1e0)]].s[1] == [2 ; 2 ;; 2 ; 2]
+        
+        # change roi, and change basedir, and prune
+        msg = "No files were kept by filters for category BACK."
+        @test_warn msg (calib = read_calibration_files_from_yaml(yamlpath ;
+                               overwrite_roi=(1:1:2, 1:1:1), basedir=subpath, prune=true))
+        @test Set(keys(calib.src_index)) == Set(["back__and__flat"])
+        @test Set(keys(calib.cat_index)) == Set(["FLAT"])
+        @test calib.stat[calib.stat_index[("FLAT",1e0)]].n == 1
+        @test calib.stat[calib.stat_index[("FLAT",1e0)]].s[1] == [101 ; 101 ;;]
+        @test calib.stat[calib.stat_index[("FLAT",10e0)]].n == 1
+        @test calib.stat[calib.stat_index[("FLAT",10e0)]].s[1] == [1010 ; 1010 ;;]
+    end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -476,7 +476,10 @@ categories:
         msg = "No files were kept by filters for category BACK."
         @test_warn msg (calib = read_calibration_files_from_yaml(yamlpath ;
                                overwrite_roi=(1:1:2, 1:1:1), basedir=subpath, prune=true))
-        @test Set(keys(calib.src_index)) == Set(["back__and__flat"])
+        #TODO: re-enable when `prune` merged in ScientificDetectors:
+        # @test Set(keys(calib.src_index)) == Set(["back__and__flat"])
+        #TODO: disable when `prune` merged in ScientificDetectors:
+        @test Set(keys(calib.src_index)) == Set(["back", "flat"])
         @test Set(keys(calib.cat_index)) == Set(["FLAT"])
         @test calib.stat[calib.stat_index[("FLAT",1e0)]].n == 1
         @test calib.stat[calib.stat_index[("FLAT",1e0)]].s[1] == [101 ; 101 ;;]

--- a/zoo/SPHERE IRDIS calibration.yml
+++ b/zoo/SPHERE IRDIS calibration.yml
@@ -1,7 +1,9 @@
+#title: Calibration IRDIS basique
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true
 exclude files: M.
 
+roi: "(:, 401:2:500)"
 
 exptime: "ESO DET SEQ1 REALDIT"
 
@@ -17,8 +19,8 @@ categories:
     sources: dark + background
 
   FLAT:
-    ESO DPR TYPE:  FLAT
-    sources: flat + dark
+    ESO DPR TYPE:  FLAT,LAMP
+    sources: flat + background + dark
 
   WAVE:
     ESO DPR TYPE:  ["LAMP,WAVE","WAVE,LAMP"]

--- a/zoo/SPHERE IRDIS calibration.yml
+++ b/zoo/SPHERE IRDIS calibration.yml
@@ -12,7 +12,7 @@ categories:
   DARK_DB_K12:
     ESO DPR TYPE: DARK
     ESO INS COMB IFLT: DB_K12
-    sources: dark 
+    sources: dark
 
   BACKGROUND:
     ESO DPR TYPE: DARK,BACKGROUND

--- a/zoo/ZIMPOL detector calibration.yml
+++ b/zoo/ZIMPOL detector calibration.yml
@@ -1,10 +1,11 @@
+title: "ZIMPOL Config"
 suffixes: [.fits, .fits.gz,.fits.Z]
 include subdirectory: true
 exclude files: M.
 
 exptime: "ESO DET DIT1"
 hdu: "Callas" #Bartolli
-#roi: (26:(512+25),9:2:(1024-8))
+roi: (26:(512+25),9:2:(1024-8))
 
 categories:
   DARK:

--- a/zoo/example1.yaml
+++ b/zoo/example1.yaml
@@ -1,10 +1,12 @@
 # We start to define our global settings
 
+title: "A YAML config example"
+
 # directory path where files will be looked for
 dir:  alice/calibration-files/
 
 # if true, sub directories will be searched too
-include subdirectory: true
+include subdirectories: true
 
 # only files whose filename ends with at least one of these suffixes will be kept
 suffixes: [.fits, .fits.gz,.fits.Z]
@@ -29,7 +31,7 @@ DATE-OBS:
 
 categories:
   FLAT:   # a first category, of name "FLAT"
-    sources: background + flat   # two sources : "background" and "flat"
+    sources: background + flat   # two sources, "background" and "flat"
     ESO INS COMB IFLT: BB_H      # a filter for this category
     ESO DPR TYPE: FLAT,LAMP      # another
 


### PR DESCRIPTION
**!! not ready to merge yet !!**

- Defines a `Config` structure to hold configurations, to be more strict, and to allow to define it without YAML.
- Defines parsers from YAML to `Config`, with a lot of informative error messages for the user.
- Refactorize `ReadCalibrationFiles` as `read_calibration_files_from_yaml`, now there is four passes:
  - first pass goes through each category and gather every possible file, based on their dirpath and filename only.
    This pass produces a Dict from category-names to list of filepaths.
  - second pass groups all categories filespaths in one big Set. It also groups all filters of the config in one big Set. Then each filepath Header is read, and keywords values for each filters are read.
    This pass produceds a a Dict from filepaths to a Dict from keyword names to keyword values.
  - third pass goes through each category and keep only files who are valid for the filters of the category, using the dict built from the second pass (so, no need to read FITS files in this third pass).
    This pass produces a Dict from category-names to filepaths (valid filepaths for the category).
  - fourth pass build a CalibrationData with a CalibrationCategory for each category, and puting each file of the category in a CalibrationDataSampler.
    
    This refactoring permits to read a FITS header only twice (once for Header and once for Data), compared to the previous process where a FITS header was read for each category. The only regression is that now, a keyword present in two different categories must have the same type for both categories. I believe this situation should be very rare, but tell me, a workaround is easy.
- Provides intensive test for the refactored code
- Reworks documentation accordingly to the modifs, and improved existing one.
- `title`  setting is back
- fix `hdu` integer or string
- removes `verb` setting, and uses `@debug` calls
- dir system is clarified, now `read_calibration_files_from_yaml` takes a `basedir` keyword parameter, which is the folder from which eventual relative path in the YAML will be resolved. Default is `pwd()`.
- added a new constructor for `CalibrationData`, which takes a `Config` as input
- fix `prune` call on undefined CalibrationData, by producing warning and errors earlier when the list of kept files is empty
