### PR TITLE
EasyFITS to AstroFITS plus   deprecation and tests fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,16 @@ version = "0.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-EasyFITS = "a977f4a2-36a7-4172-89e7-19c2726f82e5"
+AstroFITS = "34e54ef0-c5bf-48ab-9e5d-cca51f35ed77"
 ScientificDetectors = "7137afbe-ade3-4903-9296-05966c540d95"
 SimpleExpressions = "bfa79951-833f-460b-a5a3-57213acc08ae"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ScientificDetectors = "0.3"
-julia = "1"
+julia = "1.6"
+AstroFITS = "1"
+YAML = "0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/AstronomicalDetectors.jl
+++ b/src/AstronomicalDetectors.jl
@@ -20,7 +20,7 @@ export
     scan_calibrations,
     ReadCalibrationFiles
 
-using EasyFITS: FitsFile, FitsHeader, FitsImageHDU
+using AstroFITS: FitsFile, FitsHeader, FitsImageHDU
 
 using SimpleExpressions
 
@@ -124,7 +124,7 @@ end
 #    ESO DPR CATG = SCIENCE or CALIB
 #
 function default_scanner(filename::AbstractString,
-                         hdr::FitsHeader = read(FitsHeader, filename);
+                         hdr::FitsHeader = readfits(FitsHeader, filename);
                          exptime::AbstractString = "ESO DET SEQ1 REALDIT",
                          category::AbstractString = "ESO DPR TYPE")
 
@@ -200,7 +200,7 @@ function Base.read(::Type{CalibrationData{T}},
     producer = Channel{CalibrationDataFrame{T,N}}() do chn
         for item in list
             FitsFile(item.path) do file
-                hdu = FitsImageHDU(file, 1)
+                hdu = file[1]
                 naxis = hdu.data_ndims
                 width, height, nframes = item.dims
                 if naxis == N && nframes == 1

--- a/src/ReadCalibration.jl
+++ b/src/ReadCalibration.jl
@@ -1,6 +1,6 @@
 module YAMLCalibrationFiles
 
-using EasyFITS: FitsFile, FitsHeader, FitsImageHDU
+using AstroFITS: FitsFile, FitsHeader, FitsImageHDU
 using ScientificDetectors
 using YAML
 using ScientificDetectors:CalibrationFrameSampler
@@ -22,7 +22,7 @@ function fill_filedict!(filedict::Dict{String, FitsHeader},
             if isfile(filename)
                 if endswith(filename,catdict["suffixes"])
                     get!(filedict, filename) do
-                        read(FitsHeader, filename)
+                        readfits(FitsHeader, filename)
                     end
                 end
             elseif isdir(filename) && catdict["include subdirectory"]
@@ -353,7 +353,7 @@ function ReadCalibrationFiles(yaml_file::AbstractString;
 
                 FitsFile(filename) do file
 
-                    hdu = FitsImageHDU(file, Int(catdict["hdu"]))
+                    hdu = file[catdict["hdu"]]
 
                     if isfirst
                         width, height = hdu.data_size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using AstronomicalDetectors
 using Test
-using EasyFITS
+using AstroFITS
 using Dates
 using AstronomicalDetectors.YAMLCalibrationFiles
 using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
@@ -212,7 +212,7 @@ end
                 # put one in a wrong folder to see if it is correctly excluded
                 writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
 
-                data = ReadCalibrationFiles(initialdir * "/test/example_from_the_doc.yml")
+                data = ReadCalibrationFiles(initialdir * "/example_from_the_doc.yml")
 
                 @test "FLAT"       in keys(data.cat_index)
                 @test "BACKGROUND" in keys(data.cat_index)


### PR DESCRIPTION
Uses the `AstroFITS` package instead of `EasyFITS` for FITS file handling, and updates related API calls to match the new package's interface. 

**Migration to AstroFITS and API updates:**

* Replaced all imports of `EasyFITS` with `AstroFITS` for FITS file types and functions in `src/AstronomicalDetectors.jl`, `src/ReadCalibration.jl`, and `test/runtests.jl`. [[1]](diffhunk://#diff-c53d9b9ba0b3b461f9b0cdce8b90ae4934ea863dc009c6bf5bb0f4fb1c6f4366L23-R23) [[2]](diffhunk://#diff-5f170eb7e8a063c7e1742047358c83524ab6ba483fab056239bf09f1d5ea54ceL3-R3) [[3]](diffhunk://#diff-3b9314a6f9f2d7eec1d0ef69fa76cfabafdbe6d0df923768f9ec32f27a249c63L3-R3)
* Updated FITS header reading from `read(FitsHeader, ...)` to `readfits(FitsHeader, ...)` to match the `AstroFITS` API in both main and calibration code. [[1]](diffhunk://#diff-c53d9b9ba0b3b461f9b0cdce8b90ae4934ea863dc009c6bf5bb0f4fb1c6f4366L127-R127) [[2]](diffhunk://#diff-5f170eb7e8a063c7e1742047358c83524ab6ba483fab056239bf09f1d5ea54ceL25-R25)
* Changed FITS image HDU access from `FitsImageHDU(file, idx)` to direct indexing `file[idx]` as required by `AstroFITS`. [[1]](diffhunk://#diff-c53d9b9ba0b3b461f9b0cdce8b90ae4934ea863dc009c6bf5bb0f4fb1c6f4366L203-R203) [[2]](diffhunk://#diff-5f170eb7e8a063c7e1742047358c83524ab6ba483fab056239bf09f1d5ea54ceL356-R356)

**Test and documentation alignment:**

* Fixed test path for calibration YAML file to match the test directory structure.