### PR TITLE
split process in high yml to low yml to calibdata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ projects = ["test"]
 [deps]
 AstroFITS = "34e54ef0-c5bf-48ab-9e5d-cca51f35ed77"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 ScientificDetectors = "7137afbe-ade3-4903-9296-05966c540d95"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 AstroFITS = "1"
 Dates = "1"
+ProgressMeter = "1.11.0"
 ScientificDetectors = "0.3"
 YAML = "0.4"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,6 @@
 `AstronomicalDetectors` is a Julia package to deal with the calibration files
 of astronomical detectors like those of the VLT/Sphere instrument.
 
-Example of usage:
-
-```julia
-using AstronomicalDetectors, Glob
-list = scan_calibrations(glob("SPHER.2015-12-2*", dir))
-data = read(CalibrationData{Float64}, list; roi=(501:580,601:650))
-calib = ReducedCalibration(data)
-```
-
 ## YAML configuration file
 
 To deal with the numerous configuration of the different instruments, all calibrations files and keywords can be described in a YAML configuration file (see in the [config zoo folder](zoo)).
@@ -20,8 +11,7 @@ Usage:
 
 ```julia
 using AstronomicalDetectors, ScientificDetectors
-data = ReadCalibrationFiles("ymlfile.yml"; dir="path/to/calib/folder")
-calib = ReducedCalibration(data)
+calib_data = read_calibration_files("myconfig.yml")
 ```
 
 A YAML file should be as follow :

--- a/src/AstronomicalDetectors.jl
+++ b/src/AstronomicalDetectors.jl
@@ -18,7 +18,7 @@ export
     CalibrationData,
     CalibrationInformation,
     scan_calibrations,
-    ReadCalibrationFiles
+    read_calibration_files
 
 using AstroFITS: FitsFile, FitsHeader
 
@@ -27,7 +27,7 @@ using ScientificDetectors: CalibrationCategory
 
 
 include("ReadCalibration.jl")
-import .YAMLCalibrationFiles: ReadCalibrationFiles
+import .YAMLCalibrationFiles: read_calibration_files
 
 struct CalibrationInformation
     path::String             # FITS file

--- a/src/ReadCalibration.jl
+++ b/src/ReadCalibration.jl
@@ -6,9 +6,10 @@ using YAML
 using ScientificDetectors:CalibrationFrameSampler
 using Dates
 import ScientificDetectors.Calibration: prunecalibration
+using ProgressMeter
 
 
-function find_files(
+function gather_filepaths(
     paths ::Vector{String}
     ; level::Int=0,
       maxlevel::Int=0,
@@ -26,40 +27,36 @@ function find_files(
             push!(found_files, path)
         elseif isdir(path)
             subpaths = readdir(path; join=true, sort=false)
-            sub_found_files = find_files(subpaths; level=level+1, maxlevel, suffixes, exclude)
+            sub_found_files = gather_filepaths(subpaths; level=level+1, maxlevel, suffixes, exclude)
             union!(found_files, sub_found_files)
         else
             @error "unhandled path \"$path\""
         end
     end
     
-    return found_files
+    found_files
 end
 
-function find_config_files!(
-    filecache::Dict{String,FitsHeader},
-    config::Dict{String,Any})
+function gather_filepaths_cat(
+    cat_config::Dict{String,Any})
 
-    suffixes = config["suffixes"]
-    exclude  = config["exclude files"]
+    found_files = Set{String}()
 
-    found_files = find_files([config["dir"]]; suffixes, exclude,
-        maxlevel = config["include subdirectory"] ? -1 : 0)
+    union!(found_files, gather_filepaths([cat_config["dir"]]
+                                         ; suffixes = cat_config["suffixes"],
+                                           exclude  = cat_config["exclude files"],
+                                           level    = 0,
+                                           maxlevel = cat_config["include subdirectory"] ? -1 : 0))
 
-    if haskey(config, "files")
-        merge!(found_files, find_files(config["files"]; suffixes, exclude,
-            maxlevel = config["include subdirectory"] ? -1 : 1))
-            # maxlevel can be 1, because `files` can contain dir paths too, and we want to
-            # include their direct content, even when `include subdirectory` is false
-    end
-    
-    for file in found_files
-        get!(filecache, file) do
-            readfits(FitsHeader, file)
-        end
-    end
-    
-    return Dict{String,FitsHeader}(path => filecache[path] for path in found_files)
+    union!(found_files, gather_filepaths(cat_config["files"]
+                                         ; suffixes = cat_config["suffixes"],
+                                           exclude  = cat_config["exclude files"],
+                                           level    = 0,
+                                           maxlevel = cat_config["include subdirectory"] ? -1 : 1))
+                                           # maxlevel is 1, because `files` can contain dir paths
+                                           # too, and we want to include their direct content, even
+                                           # when `include subdirectory` is false
+    found_files
 end
 
 contains_any(arg...) = contains(arg...)
@@ -290,123 +287,222 @@ end
 Build a `newlist` dictionnary of all files where `fitsheader[keyword] == value` for all keywords contained in `cat_config`
 """
 function  filterkeyword(filelist::Dict{String, FitsHeader},
-                        cat_config::Dict{String, Any};
-                        verb::Bool=false)
+                        cat_config::Dict{String, Any})
     filteredkeywords = "(dir)|(files)|(suffixes)|(include subdirectory)|(exclude files)|(exptime)|(hdu)|(sources)|(roi)"
     keydict =  filter(p->match(Regex(filteredkeywords), p.first) === nothing,cat_config)
     if length(keydict)>0
         for (keyword,value) in keydict
-            if verb
-                initialsize = length(filelist)
-            end
             filelist =  filtercat(filelist,keyword,value)
-            if verb
-                filteredsize = length(filelist)
-                @info "from $initialsize files, kept $filteredsize, by filter $keyword=$value"
-            end
         end
     end
     return filelist
 end
 
-function get_global_config(dir::AbstractString,roi)
+function get_global_config(dir::AbstractString, roi)
     calibdict = Dict{String, Any}()
     calibdict["dir"] = dir
+    calibdict["files"] = String[]
     calibdict["hdu"] = 1
     calibdict["suffixes"] = [".fits", ".fits.gz", ".fits.Z"]
     calibdict["include subdirectory"] = true
     calibdict["exclude files"] = Vector{String}()
     calibdict["roi"] = roi
+    calibdict["exptime"] = "EXPTIME"
     return calibdict
 end
 
-function get_category_config(global_config::Dict{String, Any})
-    filteredkeywords = "(categories)";
-    category_config  = Dict{String, Any}()
-    merge!(category_config,filter(p->match(Regex(filteredkeywords), p.first) === nothing,global_config));
-    return category_config
+function get_category_config(global_config::Dict{String, Any}, yaml_cat::Dict{String,Any})
+    cat_config = filter(global_config) do (key,val); key != "categories" end 
+    merge!(cat_config, yaml_cat)
+    cat_config
 end
 
 """
-    ReadCalibrationFiles(yaml_file::AbstractString; roi::NTuple{2} = (:,:),  dir=pwd())
+    read_calibration_files(yaml_file::AbstractString, ::Type{T}=Float32; kwds...) -> CalibrationData
 
 Process calibration files according to the YAML configuration file `yaml_file`.
 
-- `roi` keyword can be used to consider only a region of interest of the detector (e.g. `roi=(1:100,1:2:100)`) default `roi=(:,:)`
-
-- `dir` is the directory containing the files. By default `dir=pwd()`. This keyword is overriden by the `dir` in the YAML config file
-
-- `prune`  by default `prune=true` remove empty categories and sources
-
-- `verb`  by default `verb=false` print information about filtering of files in categories
+# Keyword parameters
+- `reset_selected_files=true`: by default, we will read files given in `dir`, and associate files to categories. However the input YAML is allowed to have existing "selected files" fields in its categories. `reset_selected_files=true` will reset these fields before searching for files.
+- `roi=(:,:)`: consider only a region of interest of the detector (e.g. `roi=(1:100,1:2:100)`)
+- `dir=pwd()`: directory containing the files.This keyword is overriden by the `dir` in the YAML config file.
+- `prune=true`: remove empty categories and sources
+- `write_result_yaml=""`: if a non-empty path is given, the result YAML (with the fields "selected files" filled) will be written to this path.
 
 Return an instance of `CalibrationData` with all information statistics needed to calibrate the detector.
 """
-function ReadCalibrationFiles(yaml_file::AbstractString;
-                              roi = (:,:),
-                              dir = pwd(),
-                              prune::Bool=true,
-                              verb::Bool=false)
+function read_calibration_files(yaml_file::AbstractString,
+                                ::Type{T}=Float32,
+                                ; reset_selected_files::Bool=true,
+                                  roi = (:,:),
+                                  dir = pwd(),
+                                  prune::Bool=true,
+                                  write_result_yaml::String="") where {T<:AbstractFloat}
+    yaml = YAML.load_file(normpath(yaml_file); dicttype=Dict{String,Any})
+    read_calibration_files!(yaml, T; reset_selected_files, roi, dir, prune, write_result_yaml)
+end
 
-    global_config = get_global_config(dir,repr(roi))
-    merge!(global_config, YAML.load_file(yaml_file; dicttype=Dict{String,Any}))
+function read_calibration_files!(yaml::AbstractDict,
+                                 ::Type{T}=Float32,
+                                 ; reset_selected_files::Bool=true,
+                                   roi = (:,:),
+                                   dir = pwd(),
+                                   prune::Bool=true,
+                                   write_result_yaml::String="") where {T<:AbstractFloat}
+    reset_selected_files!(yaml)
+    select_files!(yaml; roi, dir)
+    isempty(write_result_yaml) || YAML.write_file(normpath(write_result_yaml), yaml)
+    calib_data = yaml_to_calibration_data(yaml, T; roi, dir, prune)
+end
 
-    filecache = Dict{String, FitsHeader}()
+function reset_selected_files!(yaml::AbstractDict)
+    for (catname,cat) in yaml["categories"]
+        delete!(cat, "selected files")
+    end
+    yaml
+end
 
-    catarr =  [CalibrationCategory(cata,Meta.parse(value["sources"])) for (cata,value) in global_config["categories"] ]
-    local caldat::CalibrationData{Float64}
-    local dataroi::DetectorAxes
-    local inds::Tuple{OrdinalRange, OrdinalRange}
-    isfirst = true
-    width, height = -1, -1
+function select_files!(yaml::AbstractDict,
+                       ; roi = (:,:),
+                         dir = pwd())
 
-    for (cat,value) in global_config["categories"]
-        cat_config =get_category_config(global_config)
-        merge!(cat_config, value)
-        cat_files = find_config_files!(filecache, cat_config)
-        verb && @info "category: $cat"
-        filtered_cat_files = filterkeyword(cat_files, cat_config; verb=verb)
-        verb && (@info keys(filtered_cat_files) ; @info "------------------")
+    global_config = get_global_config(dir, repr(roi))
+    merge!(global_config, yaml)
+
+    # we keep encountered FITS headers in a cache, so we have at most one I/O call by file
+    headers_cache = Dict{String, FitsHeader}()
+
+    for (catname,yaml_cat) in yaml["categories"]
+        cat_config = get_category_config(global_config, yaml_cat)
+
+        cat_filepaths = gather_filepaths_cat(cat_config)
+        
+        for path in cat_filepaths
+            get!(headers_cache, path) do; readfits(FitsHeader, path) end
+        end
+    
+        cat_files = Dict{String,FitsHeader}(path => headers_cache[path] for path in cat_filepaths)
+        
+        filtered_cat_files = filterkeyword(cat_files, cat_config)
+
         if !isempty(filtered_cat_files)
-            for (filename,fitshead) in filtered_cat_files
-
-                FitsFile(filename) do file
-
-                    hdu = file[cat_config["hdu"]]
-
-                    if isfirst
-                        width, height = hdu.data_size
-                        inds = (Base.OneTo(width)[eval(Meta.parse(cat_config["roi"]))[1]],
-                        Base.OneTo(height)[eval(Meta.parse(cat_config["roi"]))[2]])
-                        dataroi = DetectorAxes(inds)
-                        caldat = CalibrationData{Float64}(dataroi,catarr)
-                        isfirst = false
-                    else
-                        width  == hdu.data_size[1] || error("incompatible sizes")
-                        height == hdu.data_size[2] || error("incompatible sizes")
-                    end
-                    if hdu.data_ndims == 2
-                        data = read(hdu, inds...)
-                        sampler =  CalibrationDataFrame(cat,fitshead[cat_config["exptime"]].float,data;roi=dataroi)
-                    else
-                        data = read(hdu, (inds...,Base.OneTo(hdu.data_size[3]))...)
-
-                        if hdu.data_size[3] > 1
-                            sampler = CalibrationFrameSampler(data,cat,fitshead[cat_config["exptime"]].float;roi=dataroi)
-                        else
-                            sampler =  CalibrationDataFrame(cat,fitshead[cat_config["exptime"]].float,view(data, :,:, 1);roi=dataroi)
-                        end
-                    end
-                    push!(caldat, sampler)
-                end
+            selected_files = get!(yaml_cat, "selected files", Dict{Float64,Vector{String}}())
+            for (path, fitshead) in filtered_cat_files
+                Δt = Float64(fitshead[cat_config["exptime"]].value())
+                selected_files_Δt = get!(selected_files, Δt, String[])
+                push!(selected_files_Δt, path)
             end
         end
     end
-    if prune
-        caldat = prunecalibration(caldat)
+
+    yaml
+end
+
+function yaml_to_calibration_data(yaml::AbstractDict,
+                                  ::Type{T}=Float32
+                                  ; roi = (:,:),
+                                    dir = pwd(),
+                                    prune::Bool=true) where {T<:AbstractFloat}
+
+    global_config = get_global_config(dir, repr(roi))
+    merge!(global_config, yaml)
+    
+    # first pass where we:
+    # - count the number of files
+    # - resolve roi (the user is allowed to use Colons)
+    # - gather calibration categories
+    # we use two pass, because ScientificDetectors does not have the
+    # method `push!(::CalibrationData, ::CalibrationCategory)` so we have to
+    # create every calibration category before adding data
+    nb_files = 0
+    resolved_roi = nothing
+    calib_cats = CalibrationCategory[]
+    for (catname, yaml_cat) in yaml["categories"]
+        cat_config = get_category_config(global_config, yaml_cat)
+        
+        user_roi = eval(Meta.parse(cat_config["roi"]))
+
+        for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
+            nb_files += length(fitspaths)
+            
+            if isnothing(resolved_roi)
+                fitspath = first(fitspaths)
+                size = FitsFile(f -> f[cat_config["hdu"]].data_size, fitspath)
+                inds = ntuple(length(user_roi)) do k
+                    Base.OneTo(size[k])[ user_roi[k] ]
+                end
+                resolved_roi = DetectorAxes(inds)
+            end
+            
+            push!(calib_cats, CalibrationCategory(catname, Meta.parse(cat_config["sources"])))
+        end
     end
 
-    return caldat
+    isempty(nb_files) && argument_error("`yaml` must give at least one calibration file")
+
+    calib_data = CalibrationData{T}(resolved_roi, calib_cats)
+    
+    # second pass where we read the data from FITS files
+    progress = Progress(nb_files; desc="reading calibration files")
+    for (catname, yaml_cat) in yaml["categories"]
+        cat_config = get_category_config(global_config, yaml_cat)
+        
+        for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
+            for fitspath in fitspaths
+                sampler = read_sampler(fitspath, catname, Δt, resolved_roi, T, cat_config["hdu"])
+                push!(calib_data, sampler)
+            end
+            next!(progress)
+        end
+    end
+    finish!(progress)
+
+    if prune
+        calib_data = prunecalibration(calib_data)
+    end
+
+    calib_data
+end
+
+function read_sampler(fitspath::String,
+                      catname::String,
+                      Δt::Real,
+                      roi::DetectorAxes{N},
+                      ::Type{T}=Float32,
+                      hdu::Union{Integer,String}=1,
+) where {N,T}
+    all(ax -> ax.bin == 1, roi) || error("only bin=1 is handled for now")
+    FitsFile(fitspath) do fits
+        hdu = fits[hdu]
+        
+        (hdu isa FitsImageHDU) || argument_error(
+            "in FITS file \"$fitspath", HDU \"$hdu\" must be an image")
+
+        Δt = T(Δt) # convert to T, because ScientificDetectors allows only this
+
+        if hdu.data_ndims == N
+            frame = read(Array{T,N}, hdu, axes(roi)...)
+            sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi)
+
+        elseif hdu.data_ndims == N+1
+
+            if hdu.data_size[N+1] == 1
+                frame = read(Array{T,N}, hdu, axes(roi)..., 1)
+                sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi)
+
+            else
+                cube = read(Array{T,N+1}, hdu, axes(roi)..., :)
+                sampler = CalibrationFrameSampler(cube, catname, Δt; roi)
+            end
+
+        else
+            dimension_mismatch(string(
+                "in FITS file \"$fitspath\", HDU \"$hdu\" has $(hdu.data_ndims) dimensions, ",
+                "whereas we expect $N or $(N+1) dimensions for roi $roi"))
+        end
+        
+        sampler
+    end
 end
 
 end

--- a/src/ReadCalibration.jl
+++ b/src/ReadCalibration.jl
@@ -288,7 +288,7 @@ Build a `newlist` dictionnary of all files where `fitsheader[keyword] == value` 
 """
 function  filterkeyword(filelist::Dict{String, FitsHeader},
                         cat_config::Dict{String, Any})
-    filteredkeywords = "(dir)|(files)|(suffixes)|(include subdirectory)|(exclude files)|(exptime)|(hdu)|(sources)|(roi)"
+    filteredkeywords = "(dir)|(files)|(suffixes)|(include subdirectory)|(exclude files)|(exptime)|(hdu)|(sources)|(sub roi)|(selected files)"
     keydict =  filter(p->match(Regex(filteredkeywords), p.first) === nothing,cat_config)
     if length(keydict)>0
         for (keyword,value) in keydict
@@ -298,7 +298,7 @@ function  filterkeyword(filelist::Dict{String, FitsHeader},
     return filelist
 end
 
-function get_global_config(dir::AbstractString, roi)
+function get_global_config(dir::AbstractString, sub_roi)
     calibdict = Dict{String, Any}()
     calibdict["dir"] = dir
     calibdict["files"] = String[]
@@ -306,7 +306,7 @@ function get_global_config(dir::AbstractString, roi)
     calibdict["suffixes"] = [".fits", ".fits.gz", ".fits.Z"]
     calibdict["include subdirectory"] = true
     calibdict["exclude files"] = Vector{String}()
-    calibdict["roi"] = roi
+    calibdict["sub roi"] = sub_roi
     calibdict["exptime"] = "EXPTIME"
     return calibdict
 end
@@ -324,7 +324,7 @@ Process calibration files according to the YAML configuration file `yaml_file`.
 
 # Keyword parameters
 - `reset_selected_files=true`: by default, we will read files given in `dir`, and associate files to categories. However the input YAML is allowed to have existing "selected files" fields in its categories. `reset_selected_files=true` will reset these fields before searching for files.
-- `roi=(:,:)`: consider only a region of interest of the detector (e.g. `roi=(1:100,1:2:100)`)
+- `sub_roi=(:,:)`: take only a region of interest of the input FITS files (e.g. `sub_roi=(1:100,1:2:100)`). It's called "sub roi" because the input files may already have a ROI (some instruments allow it). There is no method to extract the ROI from the input FITS files yet.
 - `dir=pwd()`: directory containing the files.This keyword is overriden by the `dir` in the YAML config file.
 - `prune=true`: remove empty categories and sources
 - `write_result_yaml=""`: if a non-empty path is given, the result YAML (with the fields "selected files" filled) will be written to this path.
@@ -334,25 +334,25 @@ Return an instance of `CalibrationData` with all information statistics needed t
 function read_calibration_files(yaml_file::AbstractString,
                                 ::Type{T}=Float32,
                                 ; reset_selected_files::Bool=true,
-                                  roi = (:,:),
+                                  sub_roi = (:,:),
                                   dir = pwd(),
                                   prune::Bool=true,
                                   write_result_yaml::String="") where {T<:AbstractFloat}
     yaml = YAML.load_file(normpath(yaml_file); dicttype=Dict{String,Any})
-    read_calibration_files!(yaml, T; reset_selected_files, roi, dir, prune, write_result_yaml)
+    read_calibration_files!(yaml, T; reset_selected_files, sub_roi, dir, prune, write_result_yaml)
 end
 
 function read_calibration_files!(yaml::AbstractDict,
                                  ::Type{T}=Float32,
                                  ; reset_selected_files::Bool=true,
-                                   roi = (:,:),
+                                   sub_roi = (:,:),
                                    dir = pwd(),
                                    prune::Bool=true,
                                    write_result_yaml::String="") where {T<:AbstractFloat}
     reset_selected_files!(yaml)
-    select_files!(yaml; roi, dir)
+    select_files!(yaml; sub_roi, dir)
     isempty(write_result_yaml) || YAML.write_file(normpath(write_result_yaml), yaml)
-    calib_data = yaml_to_calibration_data(yaml, T; roi, dir, prune)
+    calib_data = yaml_to_calibration_data(yaml, T; sub_roi, dir, prune)
 end
 
 function reset_selected_files!(yaml::AbstractDict)
@@ -363,10 +363,10 @@ function reset_selected_files!(yaml::AbstractDict)
 end
 
 function select_files!(yaml::AbstractDict,
-                       ; roi = (:,:),
+                       ; sub_roi = (:,:),
                          dir = pwd())
 
-    global_config = get_global_config(dir, repr(roi))
+    global_config = get_global_config(dir, repr(sub_roi))
     merge!(global_config, yaml)
 
     # we keep encountered FITS headers in a cache, so we have at most one I/O call by file
@@ -400,38 +400,38 @@ end
 
 function yaml_to_calibration_data(yaml::AbstractDict,
                                   ::Type{T}=Float32
-                                  ; roi = (:,:),
+                                  ; sub_roi = (:,:),
                                     dir = pwd(),
                                     prune::Bool=true) where {T<:AbstractFloat}
 
-    global_config = get_global_config(dir, repr(roi))
+    global_config = get_global_config(dir, repr(sub_roi))
     merge!(global_config, yaml)
     
     # first pass where we:
     # - count the number of files
-    # - resolve roi (the user is allowed to use Colons)
+    # - resolve sub_roi (the user is allowed to use Colons)
     # - gather calibration categories
     # we use two pass, because ScientificDetectors does not have the
     # method `push!(::CalibrationData, ::CalibrationCategory)` so we have to
     # create every calibration category before adding data
     nb_files = 0
-    resolved_roi = nothing
+    sub_roi = nothing
     calib_cats = CalibrationCategory[]
     for (catname, yaml_cat) in yaml["categories"]
         cat_config = get_category_config(global_config, yaml_cat)
         
-        user_roi = eval(Meta.parse(cat_config["roi"]))
 
         for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
             nb_files += length(fitspaths)
             
-            if isnothing(resolved_roi)
+            if isnothing(sub_roi)
                 fitspath = first(fitspaths)
                 size = FitsFile(f -> f[cat_config["hdu"]].data_size, fitspath)
-                inds = ntuple(length(user_roi)) do k
-                    Base.OneTo(size[k])[ user_roi[k] ]
+                yaml_sub_roi = eval(Meta.parse(cat_config["sub roi"]))
+                inds = ntuple(length(yaml_sub_roi)) do k
+                    Base.OneTo(size[k])[ yaml_sub_roi[k] ]
                 end
-                resolved_roi = DetectorAxes(inds)
+                sub_roi = DetectorAxes(inds)
             end
             
             push!(calib_cats, CalibrationCategory(catname, Meta.parse(cat_config["sources"])))
@@ -440,7 +440,7 @@ function yaml_to_calibration_data(yaml::AbstractDict,
 
     isempty(nb_files) && argument_error("`yaml` must give at least one calibration file")
 
-    calib_data = CalibrationData{T}(resolved_roi, calib_cats)
+    calib_data = CalibrationData{T}(sub_roi, calib_cats)
     
     # second pass where we read the data from FITS files
     progress = Progress(nb_files; desc="reading calibration files")
@@ -449,7 +449,7 @@ function yaml_to_calibration_data(yaml::AbstractDict,
         
         for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
             for fitspath in fitspaths
-                sampler = read_sampler(fitspath, catname, Δt, resolved_roi, T, cat_config["hdu"])
+                sampler = read_sampler(fitspath, catname, Δt, sub_roi, T, cat_config["hdu"])
                 push!(calib_data, sampler)
             end
             next!(progress)
@@ -467,11 +467,11 @@ end
 function read_sampler(fitspath::String,
                       catname::String,
                       Δt::Real,
-                      roi::DetectorAxes{N},
+                      sub_roi::DetectorAxes{N},
                       ::Type{T}=Float32,
                       hdu::Union{Integer,String}=1,
 ) where {N,T}
-    all(ax -> ax.bin == 1, roi) || error("only bin=1 is handled for now")
+    all(ax -> ax.bin == 1, sub_roi) || error("only bin=1 is handled")
     FitsFile(fitspath) do fits
         hdu = fits[hdu]
         
@@ -481,24 +481,24 @@ function read_sampler(fitspath::String,
         Δt = T(Δt) # convert to T, because ScientificDetectors allows only this
 
         if hdu.data_ndims == N
-            frame = read(Array{T,N}, hdu, axes(roi)...)
-            sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi)
+            frame = read(Array{T,N}, hdu, axes(sub_roi)...)
+            sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi=sub_roi)
 
         elseif hdu.data_ndims == N+1
 
             if hdu.data_size[N+1] == 1
-                frame = read(Array{T,N}, hdu, axes(roi)..., 1)
-                sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi)
+                frame = read(Array{T,N}, hdu, axes(sub_roi)..., 1)
+                sampler = CalibrationDataFrame{T,N}(catname, Δt, frame; roi=sub_roi)
 
             else
-                cube = read(Array{T,N+1}, hdu, axes(roi)..., :)
-                sampler = CalibrationFrameSampler(cube, catname, Δt; roi)
+                cube = read(Array{T,N+1}, hdu, axes(sub_roi)..., :)
+                sampler = CalibrationFrameSampler(cube, catname, Δt; roi=sub_roi)
             end
 
         else
             dimension_mismatch(string(
                 "in FITS file \"$fitspath\", HDU \"$hdu\" has $(hdu.data_ndims) dimensions, ",
-                "whereas we expect $N or $(N+1) dimensions for roi $roi"))
+                "whereas we expect $N or $(N+1) dimensions for sub_roi $sub_roi"))
         end
         
         sampler

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,6 +4,7 @@ AstronomicalDetectors = "482535f4-4eff-4998-8428-5ff2b5e59f9e"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [sources]
 AstronomicalDetectors = {path = ".."}

--- a/test/example_from_the_doc.yml
+++ b/test/example_from_the_doc.yml
@@ -35,6 +35,7 @@ categories:
 
   BACKGROUND:  # another category, of name "BACKGROUND"
     sources: background
+    hdu: "ABCD"           # changing the data hdu setting for this category
     ESO DPR TYPE: ["DARK", "DARK,BACKGROUND"]   # at least one of these values must hold
 
   WAVE:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,7 +203,8 @@ end
 
                 hdr2 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
                                   "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "DARK")
-                writefits!("alice/calibration-files/subfolder/file2.fits", hdr2, [1;;])
+                writefits!("alice/calibration-files/subfolder/file2.fits",
+                    hdr2, [0;;], FitsHeader("EXTNAME" => "ABCD"), [1;;])
 
                 hdr3 = FitsHeader("SPECIAL DIT KEYWORD" => 1e0, "INSTRUME" => "SPHERE",
                                   "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "LAMP,WAVE")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Dates
 using AstronomicalDetectors.YAMLCalibrationFiles
 using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
 using StatsBase: nobs
+using YAML
 
 @testset "AstronomicalDetectors.jl" begin
     # Write your tests here.
@@ -179,17 +180,15 @@ end
                    """
             write(pathyaml, yaml)
             writefits!(pathfits, hdr, Int[0 0 ; 0 0])
-            ReadCalibrationFiles(pathyaml; dir=pathdir)
+            read_calibration_files(pathyaml; dir=pathdir)
 
         end end end
     end
 
-    @testset "ReadCalibrationFiles with example_from_the_doc.yml" begin
+    @testset "read_calibration_files with example_from_the_doc.yml" begin
         initialdir = pwd()
-        try
-            mktempdir() do pathdir
-
-                cd(pathdir)
+        mktempdir() do pathdir
+            cd(pathdir) do
 
                 # build directory structure like in the example
                 mkdir("alice")
@@ -213,18 +212,27 @@ end
                 # put one in a wrong folder to see if it is correctly excluded
                 writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
 
-                data = ReadCalibrationFiles(initialdir * "/example_from_the_doc.yml")
+                calib_data = read_calibration_files(initialdir * "/example_from_the_doc.yml"
+                                              ; write_result_yaml="result.yml")
 
-                @test "FLAT"       in keys(data.cat_index)
-                @test "BACKGROUND" in keys(data.cat_index)
-                @test "WAVE"       in keys(data.cat_index)
-                @test "flat"       in keys(data.src_index)
-                @test "background" in keys(data.src_index)
-                @test "wave"       in keys(data.src_index)
-                @test maximum(nobs(data.stat[data.stat_index[("FLAT",1)      ]])) == 1
-                @test maximum(nobs(data.stat[data.stat_index[("BACKGROUND",1)]])) == 1
-                @test maximum(nobs(data.stat[data.stat_index[("WAVE",1)      ]])) == 1
+                result = YAML.load_file("result.yml")
+
+                @test "FLAT"       in keys(calib_data.cat_index)
+                @test "BACKGROUND" in keys(calib_data.cat_index)
+                @test "WAVE"       in keys(calib_data.cat_index)
+                @test "flat"       in keys(calib_data.src_index)
+                @test "background" in keys(calib_data.src_index)
+                @test "wave"       in keys(calib_data.src_index)
+                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("FLAT",1)      ]])) == 1
+                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("BACKGROUND",1)]])) == 1
+                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("WAVE",1)      ]])) == 1
+                @test result["categories"]["FLAT"]["selected files"][1e0] == [
+                    "alice/calibration-files/file1.fits" ]
+                @test result["categories"]["BACKGROUND"]["selected files"][1e0] == [
+                    "alice/calibration-files/subfolder/file2.fits" ]
+                @test result["categories"]["WAVE"]["selected files"][1e0] == [
+                    "alice/wave-calibration-folder/file3.fits" ]
             end
-        finally cd(initialdir) end
+        end
     end
 end


### PR DESCRIPTION
- split ReadCalibrationFiles process in two: first edit the yaml, then construct the CalibrationData
- add "selected files" field to the yaml categories. thus we have a "high" level yaml, with only instruction on which dir to use, which category to construct and which keyword to filter with; and a "low" level yaml, the same but with "selected files" fields, i.e the result of the actual association of files paths to categories
- some renaming
- small refactor of the header cache: it is no longer linked to the search of candidate file paths
- extracted the FITS data reading to its own function: `read_sampler`. it handles the dimension thing, and it is in prevision of being able to support OnlineSampleStatistics FITS data too (in a future PR)
- some yaml fields are not tested yet or not enough tested. a refactor of the test, to split them into the newly splitted functions, would be good to do