### PR TITLE
get rid of the scanner (issue #16)

### DIFF
--- a/src/AstronomicalDetectors.jl
+++ b/src/AstronomicalDetectors.jl
@@ -5,229 +5,25 @@ astronomical detectors like those of the VLT/Sphere instrument.
 
 Example of usage:
 
-    using AstronomicalDetectors, Glob
-    list = scan_calibrations(glob("SPHER.2015-12-2*", dir))
-    data = read(CalibrationData{Float64}, list; part=(501:580,601:650))
-    calib = ReducedCalibration(data)
+    using AstronomicalDetectors
+    calib_data = read_calibration_files("myconfig.yaml"; dir="mycalibfiles/")
 
 """
 module AstronomicalDetectors
 
 export
-    CalibrationCategory,
     CalibrationData,
-    CalibrationInformation,
-    scan_calibrations,
     read_calibration_files,
     select_files!,
     yaml_to_calibration_data
 
-using AstroFITS: FitsFile, FitsHeader
-
+using AstroFITS
 using ScientificDetectors
-using ScientificDetectors: CalibrationCategory
+using OnlineSampleStatistics
+using YAML
+using Dates
+using ProgressMeter
 
-
-include("ReadCalibration.jl")
-import .YAMLCalibrationFiles: read_calibration_files, select_files!, yaml_to_calibration_data
-
-struct CalibrationInformation
-    path::String             # FITS file
-    dims::NTuple{3,Int}      # (width,height,nframes)
-    Δt::Float64              # exposure time (seconds)
-    cat::CalibrationCategory # calibration category
-end
-
-"""
-    lst = scan_calibrations(args...; scanner=default_scanner, kwds...)
-
-scans calibration data files specified as arguments (file and/or directory
-names) and returns a list that can be used by `read(CalibrationData,...)` to
-produce an instance of `CalibrationData`.
-
-See [`AstronomicalDetectors.scan_calibration!](@ref) for a
-description of available keywords.
-
-Example:
-
-    using AstronomicalDetectors, Glob
-    lst = scan_calibrations(glob("SPHER.2015-12-2*", dir))
-
-"""
-function scan_calibrations(args::Union{AbstractString,
-                                       AbstractVector{<:AbstractString}}...;
-                           kdws...)
-    # Auxiliary functions for channels that yield filenames.
-    function yield_filenames(out::Channel, A::AbstractVector{<:AbstractString})
-        for name in A
-            yield_filenames(out, name)
-        end
-    end
-    function yield_filenames(out::Channel, name::AbstractString)
-        if isfile(name)
-            put!(out, name)
-        elseif isdir(name)
-            for other in readdir(name; join=true, sort=false)
-                isfile(other) && put!(out, other)
-            end
-        end
-    end
-
-    # Build a channel that yields all file names.
-    chnl = Channel{String}() do out
-        for arg in args
-            yield_filenames(out, arg)
-        end
-    end
-
-    # Collect all calibration information.
-    list = CalibrationInformation[]
-    for filename in chnl
-        scan_calibration!(list, filename; kdws...)
-    end
-    return list
-end
-
-"""
-    scan_calibration!(dst, filename; scanner=default_scanner, kwds...) -> dst
-
-scans the calibration information if FITS file `filename` and pushes this
-information in destination `dst` which is returned.
-
-Keyword `scanner` may be used to specifiy your own method for scanning
-calibration information.  The method is called as:
-
-    scanner(filename; kwds...)
-
-and shall return an instance of `CalibrationInformation` for the given file.
-
-All other keywords `kwds...` specified in the call to `scan_calibration!` are
-passed to the scanner.  The default scanner accept the following keywords:
-
-- Keyword `exptime` can be set with the name of the FITS card which stores the
-  exposure time (in seconds).  By default `exptime="ESO DET SEQ1 REALDIT"`.
-
-- Keyword `category` can be set with the name of the FITS card which stores the
-  calibration category.  By default `category = "ESO DPR TYPE"`.
-
-"""
-function scan_calibration!(dest::Vector{<:CalibrationInformation},
-                           filename::AbstractString;
-                           scanner = default_scanner,
-                           kwds...)
-    isfile(filename) || error("\"", filename, "\" is not a file")
-    return push!(dest, scanner(filename; kwds...))
-end
-
-# Calibration categories.
-#    OBJECT ≈ ESO DPR TYPE  except for science which yields "OBJECT"
-#    ESO DPR CATG = SCIENCE or CALIB
-#
-function default_scanner(filename::AbstractString,
-                         hdr::FitsHeader = readfits(FitsHeader, filename);
-                         exptime::AbstractString = "ESO DET SEQ1 REALDIT",
-                         category::AbstractString = "ESO DPR TYPE")
-
-    # Get dimensions.
-    naxis = hdr["NAXIS"].integer
-    if !(2 ≤ naxis ≤ 3)
-        error("other dimensions than 2D and 3D not implemented")
-    end
-    dims = (hdr["NAXIS1"].integer,
-            hdr["NAXIS2"].integer,
-            (naxis == 2 ? 1 : hdr["NAXIS3"].integer))
-
-    # Get exposure time.
-    Δt = hdr[exptime].float
-
-    # Get category of calibration and provide the corresponding linear
-    # combination of sources.
-    cat = uppercase(strip(hdr[category].string))
-    if cat == "DARK"
-        expr = :(dark)
-    elseif cat == "DARK,BACKGROUND"
-        expr = :(dark + background)
-    elseif cat == "FLAT,LAMP"
-        expr = :(dark + background + flat)
-    elseif cat == "LAMP,WAVE"
-        expr = :(dark + background + wave)
-    elseif cat == "OBJECT"
-        # Use object's name as source and category.
-        cat =  uppercase(strip(hdr["OBJECT"].string))
-        object = Symbol(lowercase(cat))
-        expr = :(dark + sky + $object)
-    elseif cat == "SKY"
-        expr = :(dark + sky)
-    else
-        @warn "unknown calibration category: \"", cat, "\" in file \"", filename, "\""
-        expr = :(dark + $cat)
-        return
-    end
-    return CalibrationInformation(filename, dims, Δt,CalibrationCategory(cat, expr))
-end
-
-"""
-    read(CalibrationData{T}, lst; part=(:,:))
-
-"""
-function Base.read(::Type{CalibrationData},
-                   list::AbstractVector{<:CalibrationInformation};
-                   kwds...)
-    return read(CalibrationData{Float64}, list; kwds...)
-end
-
-function Base.read(::Type{CalibrationData{T}},
-                   list::AbstractVector{<:CalibrationInformation};
-                   part::NTuple{2} = (:,:)) where {T<:AbstractFloat}
-    # Get detector size.
-    width, height = -1, -1
-    first = true
-    for item in list
-        if first
-            width, height = item.dims[1], item.dims[2]
-            first = false
-        else
-            (width, height) == (item.dims[1], item.dims[2]) || error(
-                "incompatible sizes")
-        end
-    end
-    inds = (Base.OneTo(width)[part[1]],
-            Base.OneTo(height)[part[2]])
-
-    # Build a calibration data frame producer.
-    N = 2 # number of dimensions
-    roi = DetectorAxes(inds)
-    producer = Channel{CalibrationDataFrame{T,N}}() do chn
-        for item in list
-            FitsFile(item.path) do file
-                hdu = file[1]
-                naxis = hdu.data_ndims
-                width, height, nframes = item.dims
-                if naxis == N && nframes == 1
-                    put!(chn, CalibrationDataFrame{T,N}(item.cat.name, item.Δt,
-                                                        read(hdu, inds...);
-                                                        roi = roi))
-                elseif naxis == N+1
-                    for j in 1:nframes
-                        put!(chn, CalibrationDataFrame{T,N}(item.cat.name, item.Δt,
-                                                            read(hdu, inds..., j);
-                                                            roi = roi))
-                    end
-                else
-                    error("other dimensions than ", N, "-D and ",
-                          N+1, "-D not implemented")
-                end
-            end
-        end
-        close(chn)
-    end
-
-    # Load all calibration data.
-    dat = CalibrationData{T}(roi, map(x -> x.cat, list))
-    for frame in producer
-        push!(dat, frame)
-    end
-    return dat
-end
+include("functions.jl")
 
 end # module

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,16 +1,3 @@
-module YAMLCalibrationFiles
-
-using AstroFITS
-using AstroFITS: FitsFile, FitsHeader, FitsImageHDU, readfits
-using ScientificDetectors
-using YAML
-using ScientificDetectors:CalibrationFrameSampler
-using Dates
-import ScientificDetectors.Calibration: prunecalibration
-using ProgressMeter
-using OnlineSampleStatistics
-
-
 function gather_filepaths(
     paths ::Vector{String}
     ; level::Int=0,
@@ -506,7 +493,7 @@ function yaml_to_calibration_data(yaml::AbstractDict,
     finish!(progress)
 
     if prune
-        calib_data = prunecalibration(calib_data)
+        calib_data = ScientificDetectors.Calibration.prunecalibration(calib_data)
     end
 
     calib_data
@@ -564,6 +551,4 @@ function read_sampler(fitspath::String,
         
         sampler
     end
-end
-
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,9 +2,9 @@
 AstroFITS = "34e54ef0-c5bf-48ab-9e5d-cca51f35ed77"
 AstronomicalDetectors = "482535f4-4eff-4998-8428-5ff2b5e59f9e"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+OnlineSampleStatistics = "455218f6-ed6f-43e9-ad07-c481a1567983"
 
 [sources]
 AstronomicalDetectors = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,238 +2,160 @@ using AstronomicalDetectors
 using Test
 using AstroFITS
 using Dates
-using AstronomicalDetectors.YAMLCalibrationFiles
-using AstronomicalDetectors.YAMLCalibrationFiles:filtercat
-using StatsBase: nobs
+using OnlineSampleStatistics
 using YAML
+using AstronomicalDetectors:filtercat
 
-@testset "AstronomicalDetectors.jl" begin
-    # Write your tests here.
-
-    @testset "default_scanner" begin
-        mktemp() do path,fileio
-            writefits(
-                path,
-                FitsHeader(
-                    "OBJECT"               => "OVNI",
-                    "ESO DET SEQ1 REALDIT" => 42e0,
-                    "ESO DPR TYPE"         => "OBJECT"),
-                [ 1 2 3 ;
-                  4 5 6 ;
-                  7 8 9 ]
-                ; overwrite = true)
-            res = nothing
-            @test_nowarn res = AstronomicalDetectors.default_scanner(path)
-            @test res isa CalibrationInformation
-            @test res.dims == (3, 3, 1)
-            @test res.Δt == 42e0
-            @test res.cat.name == "OVNI"
-            @test convert(Expr, res.cat.expr) == :(dark + sky + ovni)
-        end
-    end
-
-    @testset "read(CalibrationData, Vector{CalibrationInformation})" begin
-        mktemp() do pathobject,fileio
-            writefits(
-                pathobject,
-                FitsHeader(
-                    "OBJECT"               => "OVNI",
-                    "ESO DET SEQ1 REALDIT" => 42e0,
-                    "ESO DPR TYPE"         => "OBJECT"),
-                [ 1 2 3 ;
-                  4 5 6 ;
-                  7 8 9 ]
-                ; overwrite = true)
-            mktemp() do pathdark,fileio
-                writefits(
-                    pathdark,
-                    FitsHeader(
-                        "ESO DET SEQ1 REALDIT" => 42e0,
-                        "ESO DPR TYPE"         => "DARK"),
-                    [ 1 2 3 ;
-                      4 5 6 ;
-                      7 8 9 ]
-                    ; overwrite = true)
-                mktemp() do pathsky,fileio
-                    writefits(
-                        pathsky,
-                        FitsHeader(
-                            "ESO DET SEQ1 REALDIT" => 42e0,
-                            "ESO DPR TYPE"         => "SKY"),
-                        [ 1 2 3 ;
-                          4 5 6 ;
-                          7 8 9 ]
-                        ; overwrite = true)
-                    calibinfos = [
-                        AstronomicalDetectors.default_scanner(pathobject),
-                        AstronomicalDetectors.default_scanner(pathdark),
-                        AstronomicalDetectors.default_scanner(pathsky)]
-                    res = nothing
-                    @test_nowarn res = read(CalibrationData{Float32}, calibinfos)
-                    @test res isa CalibrationData
-                    @test size(res.roi) == (3,3)
-                    @test Set(keys(res.stat_index)) ==
-                        Set([("OVNI", 42.0), ("SKY", 42.0), ("DARK", 42.0)])
-                    #TODO more tests with more data
-                end
-            end
-        end
-    end
+@testset "filtercat single value" begin
+    hdr = FitsHeader(
+        "QUESTION" => "What is the answer?",
+        "ANSWER" => 42,
+        "CLEVER" => false,
+        "HALF" => 1.5,
+        "VOID" => nothing,
+        "ESO INFORMATIVE MESSAGE" => "I like my keyword names to be long")
+    dict = Dict("file1" => hdr)
+    @test !isempty(filtercat(dict, "QUESTION", "What is the answer?"))
+    @test !isempty(filtercat(dict, "ANSWER", 42))
+    @test !isempty(filtercat(dict, "CLEVER", false))
+    @test !isempty(filtercat(dict, "HALF", 1.5e0))
+    @test !isempty(filtercat(dict, "HALF", 1.5f0))
+    @test !isempty(filtercat(dict, "ANSWER", Int8(42)))
+    @test !isempty(filtercat(dict, "ANSWER", UInt64(42)))
+    warnmsg = "card type Float64 is != from target value type String in file file1"
+    @test_warn warnmsg filtercat(dict, "HALF", "1.5")
+    errormsg = "Complex values not yet implemented"
+    @test_throws ErrorException(errormsg) filtercat(dict, "HALF", 1.5+0im)
+    warnmsg = "card type Float64 is != from target value type Int64 in file file1"
+    @test_warn warnmsg filtercat(dict, "HALF", 1)
+    warnmsg = "card type Int64 is != from target value type Float64 in file file1"
+    @test_warn warnmsg filtercat(dict, "ANSWER", 42e0)
+    errormsg = "unsupported target value type Nothing"
+    @test_throws ErrorException(errormsg) filtercat(dict, "VOID", nothing)
+    warnmsg = "card type Nothing is != from target value type String in file file1"
+    @test_warn warnmsg filtercat(dict, "VOID", "something")
+    @test !isempty(filtercat(dict, "ESO INFORMATIVE MESSAGE",
+                                   "I like my keyword names to be long"))
 end
 
-@testset "ReadCalibration.jl" begin
+@testset "filtercat several value" begin
+    hdr = FitsHeader("GOOD" => 2)
+    dict = Dict("file1" => hdr)
+    @test !isempty(filtercat(dict, "GOOD", [1, 2]))
+    warnmsg = "card type Int64 is != from target value type Float64 in file file1"
+    @test_warn warnmsg filtercat(dict, "GOOD", [1.0, 2.0])
+    errormsg = "for keyword GOOD, eltype Any of the Vector target value is not supported"
+    @test_throws ErrorException(errormsg) filtercat(dict, "GOOD", [1, "2"])
+end
 
-    @testset "filtercat single value" begin
-        hdr = FitsHeader(
-            "QUESTION" => "What is the answer?",
-            "ANSWER" => 42,
-            "CLEVER" => false,
-            "HALF" => 1.5,
-            "VOID" => nothing,
-            "ESO INFORMATIVE MESSAGE" => "I like my keyword names to be long")
-        dict = Dict("file1" => hdr)
-        @test !isempty(filtercat(dict, "QUESTION", "What is the answer?"))
-        @test !isempty(filtercat(dict, "ANSWER", 42))
-        @test !isempty(filtercat(dict, "CLEVER", false))
-        @test !isempty(filtercat(dict, "HALF", 1.5e0))
-        @test !isempty(filtercat(dict, "HALF", 1.5f0))
-        @test !isempty(filtercat(dict, "ANSWER", Int8(42)))
-        @test !isempty(filtercat(dict, "ANSWER", UInt64(42)))
-        warnmsg = "card type Float64 is != from target value type String in file file1"
-        @test_warn warnmsg filtercat(dict, "HALF", "1.5")
-        errormsg = "Complex values not yet implemented"
-        @test_throws ErrorException(errormsg) filtercat(dict, "HALF", 1.5+0im)
-        warnmsg = "card type Float64 is != from target value type Int64 in file file1"
-        @test_warn warnmsg filtercat(dict, "HALF", 1)
-        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
-        @test_warn warnmsg filtercat(dict, "ANSWER", 42e0)
-        errormsg = "unsupported target value type Nothing"
-        @test_throws ErrorException(errormsg) filtercat(dict, "VOID", nothing)
-        warnmsg = "card type Nothing is != from target value type String in file file1"
-        @test_warn warnmsg filtercat(dict, "VOID", "something")
-        @test !isempty(filtercat(dict, "ESO INFORMATIVE MESSAGE",
-                                       "I like my keyword names to be long"))
-    end
+@testset "filtercat date range" begin
+    # date range
+    filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
+    keyword = "DATE"
+    value = Dict{String,Any}(
+        "min" => DateTime("2022-11-20T08:00:10.123"),
+        "max" => DateTime("2024-11-20T08:00:10.123"))
+    filelist2 = filtercat(filelist, keyword, value)
+    @test filelist == filelist2
 
-    @testset "filtercat several value" begin
-        hdr = FitsHeader("GOOD" => 2)
-        dict = Dict("file1" => hdr)
-        @test !isempty(filtercat(dict, "GOOD", [1, 2]))
-        warnmsg = "card type Int64 is != from target value type Float64 in file file1"
-        @test_warn warnmsg filtercat(dict, "GOOD", [1.0, 2.0])
-        errormsg = "for keyword GOOD, eltype Any of the Vector target value is not supported"
-        @test_throws ErrorException(errormsg) filtercat(dict, "GOOD", [1, "2"])
-    end
+    # date range with fitsheader date with fourth millisecond in FITS file
+    filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.1234"))
+    keyword = "DATE"
+    value = Dict{String,Any}(
+        "min" => DateTime("2022-11-20T08:00:10.123"),
+        "max" => DateTime("2024-11-20T08:00:10.123"))
+    filelist2 = filtercat(filelist, keyword, value)
+    @test filelist == filelist2
 
-    @testset "filtercat date range" begin
-        # date range
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2024-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
+    # date range exclude
+    filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
+    keyword = "DATE"
+    value = Dict{String,Any}(
+        "min" => DateTime("2022-11-20T08:00:10.123"),
+        "max" => DateTime("2023-11-20T08:00:10.123"))
+    filelist2 = filtercat(filelist, keyword, value)
+    @test isempty(filelist2)
 
-        # date range with fitsheader date with fourth millisecond in FITS file
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.1234"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2024-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
+    # date range include
+    filelist = Dict("TOTO" => FitsHeader("DATE" => "2022-11-20T08:00:10.123"))
+    keyword = "DATE"
+    value = Dict{String,Any}(
+        "min" => DateTime("2022-11-20T08:00:10.123"),
+        "max" => DateTime("2023-11-20T08:00:10.123"))
+    filelist2 = filtercat(filelist, keyword, value)
+    @test filelist == filelist2
 
-        # date range exclude
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2023-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2023-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test isempty(filelist2)
+    # yaml file, with a test with fourth millisecond
+    mktemp()        do pathyaml,fileio
+    mktempdir()     do pathdir
+    mktemp(pathdir) do pathfits,fileio
 
-        # date range include
-        filelist = Dict("TOTO" => FitsHeader("DATE" => "2022-11-20T08:00:10.123"))
-        keyword = "DATE"
-        value = Dict{String,Any}(
-            "min" => DateTime("2022-11-20T08:00:10.123"),
-            "max" => DateTime("2023-11-20T08:00:10.123"))
-        filelist2 = filtercat(filelist, keyword, value)
-        @test filelist == filelist2
+        hdr = FitsHeader("DATE" => "2023-11-20T08:00:10.1234", "TIME" => 1.1)
+        yaml = """
+               suffixes: [$pathfits]
+               exptime: "TIME"
+               categories:
+                 TOTO:
+                   DATE:
+                       min: 2022-11-20T08:00:10.1234
+                       max: 2024-11-20T08:00:10.1234
+                   sources: toto
+               """
+        write(pathyaml, yaml)
+        writefits!(pathfits, hdr, Int[0 0 ; 0 0])
+        read_calibration_files(pathyaml; dir=pathdir)
 
-        # yaml file, with a test with fourth millisecond
-        mktemp()        do pathyaml,fileio
-        mktempdir()     do pathdir
-        mktemp(pathdir) do pathfits,fileio
+    end end end
+end
 
-            hdr = FitsHeader("DATE" => "2023-11-20T08:00:10.1234", "TIME" => 1.1)
-            yaml = """
-                   suffixes: [$pathfits]
-                   exptime: "TIME"
-                   categories:
-                     TOTO:
-                       DATE:
-                           min: 2022-11-20T08:00:10.1234
-                           max: 2024-11-20T08:00:10.1234
-                       sources: toto
-                   """
-            write(pathyaml, yaml)
-            writefits!(pathfits, hdr, Int[0 0 ; 0 0])
-            read_calibration_files(pathyaml; dir=pathdir)
+@testset "read_calibration_files with example_from_the_doc.yml" begin
+    initialdir = pwd()
+    mktempdir() do pathdir
+        cd(pathdir) do
 
-        end end end
-    end
+            # build directory structure like in the example
+            mkdir("alice")
+            mkdir("alice/calibration-files")
+            mkdir("alice/calibration-files/subfolder")
+            mkdir("alice/wave-calibration-folder")
 
-    @testset "read_calibration_files with example_from_the_doc.yml" begin
-        initialdir = pwd()
-        mktempdir() do pathdir
-            cd(pathdir) do
+            hdr1 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
+                              "DATE-OBS" => "2022-04-05",
+                              "ESO INS COMB IFLT" => "BB_H", "ESO DPR TYPE" => "FLAT,LAMP")
+            writefits!("alice/calibration-files/file1.fits", hdr1, [1;;])
 
-                # build directory structure like in the example
-                mkdir("alice")
-                mkdir("alice/calibration-files")
-                mkdir("alice/calibration-files/subfolder")
-                mkdir("alice/wave-calibration-folder")
+            hdr2 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
+                              "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "DARK")
+            writefits!("alice/calibration-files/subfolder/file2.fits",
+                hdr2, [0;;], FitsHeader("EXTNAME" => "ABCD"), [1;;])
 
-                hdr1 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05",
-                                  "ESO INS COMB IFLT" => "BB_H", "ESO DPR TYPE" => "FLAT,LAMP")
-                writefits!("alice/calibration-files/file1.fits", hdr1, [1;;])
+            hdr3 = FitsHeader("SPECIAL DIT KEYWORD" => 1e0, "INSTRUME" => "SPHERE",
+                              "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "LAMP,WAVE")
+            writefits!("alice/wave-calibration-folder/file3.fits", hdr3, [1;;])
 
-                hdr2 = FitsHeader("ESO DET SEQ1 DIT" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "DARK")
-                writefits!("alice/calibration-files/subfolder/file2.fits",
-                    hdr2, [0;;], FitsHeader("EXTNAME" => "ABCD"), [1;;])
+            # put one in a wrong folder to see if it is correctly excluded
+            writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
 
-                hdr3 = FitsHeader("SPECIAL DIT KEYWORD" => 1e0, "INSTRUME" => "SPHERE",
-                                  "DATE-OBS" => "2022-04-05", "ESO DPR TYPE" => "LAMP,WAVE")
-                writefits!("alice/wave-calibration-folder/file3.fits", hdr3, [1;;])
+            calib_data = read_calibration_files(initialdir * "/example_from_the_doc.yml"
+                                          ; write_result_yaml="result.yml")
 
-                # put one in a wrong folder to see if it is correctly excluded
-                writefits!("alice/calibration-files/file3bis.fits", hdr3, [1;;])
+            result = YAML.load_file("result.yml")
 
-                calib_data = read_calibration_files(initialdir * "/example_from_the_doc.yml"
-                                              ; write_result_yaml="result.yml")
-
-                result = YAML.load_file("result.yml")
-
-                @test "FLAT"       in keys(calib_data.cat_index)
-                @test "BACKGROUND" in keys(calib_data.cat_index)
-                @test "WAVE"       in keys(calib_data.cat_index)
-                @test "flat"       in keys(calib_data.src_index)
-                @test "background" in keys(calib_data.src_index)
-                @test "wave"       in keys(calib_data.src_index)
-                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("FLAT",1)      ]])) == 1
-                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("BACKGROUND",1)]])) == 1
-                @test maximum(nobs(calib_data.stat[calib_data.stat_index[("WAVE",1)      ]])) == 1
-                @test result["categories"]["FLAT"]["selected files"][1e0] == [
-                    "alice/calibration-files/file1.fits" ]
-                @test result["categories"]["BACKGROUND"]["selected files"][1e0] == [
-                    "alice/calibration-files/subfolder/file2.fits" ]
-                @test result["categories"]["WAVE"]["selected files"][1e0] == [
-                    "alice/wave-calibration-folder/file3.fits" ]
-            end
+            @test "FLAT"       in keys(calib_data.cat_index)
+            @test "BACKGROUND" in keys(calib_data.cat_index)
+            @test "WAVE"       in keys(calib_data.cat_index)
+            @test "flat"       in keys(calib_data.src_index)
+            @test "background" in keys(calib_data.src_index)
+            @test "wave"       in keys(calib_data.src_index)
+            @test maximum(nobs(calib_data.stat[calib_data.stat_index[("FLAT",1)      ]])) == 1
+            @test maximum(nobs(calib_data.stat[calib_data.stat_index[("BACKGROUND",1)]])) == 1
+            @test maximum(nobs(calib_data.stat[calib_data.stat_index[("WAVE",1)      ]])) == 1
+            @test result["categories"]["FLAT"]["selected files"][1e0] == [
+                "alice/calibration-files/file1.fits" ]
+            @test result["categories"]["BACKGROUND"]["selected files"][1e0] == [
+                "alice/calibration-files/subfolder/file2.fits" ]
+            @test result["categories"]["WAVE"]["selected files"][1e0] == [
+                "alice/wave-calibration-folder/file3.fits" ]
         end
     end
 end


### PR DESCRIPTION
- resolves issue https://github.com/emmt/AstronomicalDetectors.jl/issues/16
- removes all the code of the scanner
- removes and updates the docs talking about the scanner
- extract the rest of the code from the now useless submodule
- updates the tests accordingly to this
- removes some useless imports
- we still need to reference a new version of ScientificDetectors, as soon as a new version will be registered