### PR TITLE
refactor config parameters, upd readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,24 +44,24 @@ categories:
     sources: dark + wave
 ```
 
-The mandatory keywords are:
+The mandatory parts are:
 
-- `exptime` : the FITS keyword containing the integration time
 - `categories` : lists all calibration categories (e.g. FLAT, DARK,...)
 - `sources` : the sources corresponding to the parent category (mandatory for each category).
 
 In this example, the calibration files are identified by their `ESO DPR TYPE` keyword.  If several values are allowed, they can be given in a array (as for the `WAVE` category in this example). If several keywords are given (as for the `FLAT` category) all of them must be valid. A date range can also be given, see more info below.
 
-Optional keywords are:
+Possible settings are:
 
-- `dir` :  the folder containing the calibration files (default `pwd`),
-- `files` : list of files or pattern,
-- `suffixes` : suffixes of the files  (default `[.fits, .fits.gz,.fits.Z]`),
-- `include subdirectory` : if `true` parse all subdirectories
-- `exclude files` : patterns of files that must be excluded
+- `dir` :  the folder containing the calibration files (default `pwd()`),
+- `files` : additional list of files paths to look for,
+- `suffixes` : restricted suffixes for the files paths  (default `[.fits, .fits.gz,.fits.Z]`),
+- `include subdirectory` : if `true` parse all subdirectories (default `true`)
+- `exclude files` : substrings of files paths that are excluded (default empty list).
 - `hdu` : name of the FITS HDU that contains the data (default `primary`).
+- `typefloat`: floating type to use for `CalibrationData`, default `Float32`.
 
-All the keywords given in the root of the file are set for all the categories (as `suffixes` in the example) but this can be overiden by keywords in each category (as `exptime` in the example).
+These settings have default values. The user can overwrite the global settings by giving some explicitly in the `config` parameter of the `read_calibration_files` function. Moreover, every setting defined *inside* a category takes precedence.
 
 It is possible to restrict the calibration files by a range of dates:
 ```yaml

--- a/doc/src/yaml_syntax.md
+++ b/doc/src/yaml_syntax.md
@@ -29,7 +29,6 @@ dir: alice/calibration-files/
 `dir` is the name of the setting and `alice/calibration-files/` is the value of the setting.
 This one tells AstronomicalDetectors the folder in which to look for FITS files.
 
-The setting `exptime` is mandatory.
 
 ### Global Filters
 
@@ -53,9 +52,12 @@ Where you describe the categories. A category has the following structure:
 
 ```
 categories:
-    NAME:
-        category settings
-        category filters
+    MY_CATEGORY_NAME:
+        dir: "my-category-folder"
+        ... others settings
+        "MY KEYWORD": TRUE
+        ... other filters
+        sources: cat_main_src + dark_src
 ```
 `categories:` is the line announcing the categories section, you write it only once in the file.
 
@@ -75,6 +77,14 @@ You must indent categories (with spaces, tabs are forbidden).
 
 Any category setting hides any global setting of the same name. It is the same for filters.
 
+### Overwriting settings and filters
+
+Every setting has a default value, apart from the `sources` settings for categories.
+
+From the Julia API, the user can overwrite global YAML settings, by giving some explicitly to the Julia function. For example he can overwrite the global "include subdirectory" setting.
+
+Any setting or filter defined in a category takes precedence over the eventually existing global one. For example if you set the "dir" in a category, it will be this for this category, no matter any other settings for "dir" elsewhere.
+
 ## Available Settings
 
 Names of the settings must be in lower case.
@@ -85,8 +95,6 @@ The setting `exptime` gives a keyword name, that keyword must contain the inform
 integration time.
 
 Type is `String`.
-
-Mandatory (it has no default value).
 
 ### sources
 
@@ -113,8 +121,7 @@ The setting `dir` instructs in which folder to look. Absolute and relative paths
 
 Type is `String`.
 
-When unspecified, the one given to the Julia function is used, and when also unspecified,
-working directory is used.
+Default is `pwd()`.
 
 ### include subdirectory
 
@@ -122,7 +129,7 @@ The setting `include subdirectory`, if `true`, instructs to search in the sub fo
 
 Type is `Bool`.
 
-When unspecified, `true` is used.
+Default is `true`.
 
 ### hdu
 
@@ -130,7 +137,7 @@ The setting `hdu` gives the number of the FITS HeaderDataUnit to use.
 
 Type is `Int`.
 
-When unspecified, `1` is used, which points to the primary HDU.
+Default is `1`, which points to the primary HDU.
 
 ### suffixes
 
@@ -139,7 +146,7 @@ in at least one of the given `String` is kept.
 
 Type is `List of String`.
 
-When unspecified, `[.fits, .fits.gz, .fits.Z]` is used.
+Default is `[.fits, .fits.gz, .fits.Z]`.
 
 ### exclude files
 
@@ -148,7 +155,7 @@ filename contains at least one of the given `String` is rejected.
 
 Type is `List of String`
 
-When unspecified, `[]` is used.
+Default is `[]`.
 
 ### roi
 
@@ -157,21 +164,19 @@ The setting `roi` gives the Region Of Interest of the detector.
 Type is `List of String of size 2`. But the `String` is in the form of a Julia `UnitRange`, for
 example `100:493`.
 
-When unspecified, the one given to the Julia function is used, and when also unspecified, `[:, :]`
-is used, which means the whole array is used.
+Default is "(:,:)" which means the whole detector matrix, whatever its size.
 
-Only global setting.
+You must use the same ROI for every category, otherwise the program fails.
 
 ### files
 
 The setting `files` gives a list of additional files to take.
 
 They are still subject to the settings `exclude files` and `suffixes`.
-A category setting for `files` hides a global setting for `files`.
 
 Type is `List of String`.
 
-When unspecified, `[]` is used.
+Default is `[]`.
 
 ## Available Filters
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -28,8 +28,7 @@ function gather_filepaths(
     found_files
 end
 
-function gather_filepaths_cat(
-    cat_config::AbstractDict{String,Any})
+function gather_filepaths_cat(cat_config::AbstractDict)
 
     found_files = Set{String}()
 
@@ -292,14 +291,14 @@ end
 
 
 """
-    newlist = filtercat(filelist::Dict{String, FitsHeader},cat_config::Dict{String, Any})
+    newlist = filtercat(filelist::Dict{String, FitsHeader},cat_config::AbstractDict)
 
 Build a `newlist` dictionnary of all files where `fitsheader[keyword] == value` for all keywords contained in `cat_config`
 """
 function  filterkeyword(filelist::AbstractDict{String, FitsHeader},
-                        cat_config::AbstractDict{String, Any};
+                        cat_config::AbstractDict;
                         verbose::Bool=false)
-    filteredkeywords = "(dir)|(files)|(suffixes)|(include subdirectory)|(exclude files)|(exptime)|(hdu)|(sources)|(roi)|(selected files)"
+    filteredkeywords = "(dir)|(files)|(suffixes)|(include subdirectory)|(exclude files)|(exptime)|(hdu)|(sources)|(roi)|(selected files)|(typefloat)|(categories)"
     keydict =  filter(p->match(Regex(filteredkeywords), p.first) === nothing,cat_config)
     if length(keydict)>0
         for (keyword,value) in keydict
@@ -309,63 +308,58 @@ function  filterkeyword(filelist::AbstractDict{String, FitsHeader},
     return filelist
 end
 
-function get_global_config(dir::AbstractString, roi)
-    calibdict = Dict{String, Any}()
-    calibdict["dir"] = dir
-    calibdict["files"] = String[]
-    calibdict["hdu"] = 1
-    calibdict["suffixes"] = [".fits", ".fits.gz", ".fits.Z"]
-    calibdict["include subdirectory"] = true
-    calibdict["exclude files"] = Vector{String}()
-    calibdict["roi"] = roi
-    calibdict["exptime"] = "EXPTIME"
-    return calibdict
-end
-
-function get_category_config(global_config::AbstractDict{String, Any}, yaml_cat::AbstractDict{String,Any})
-    cat_config = filter(global_config) do (key,val); key != "categories" end 
-    merge!(cat_config, yaml_cat)
-    cat_config
+function get_default_config()
+    Dict(
+        "roi" => "(:,:)",
+        "dir" => pwd(),
+        "files" => String[],
+        "hdu" => 1,
+        "suffixes" => [".fits", ".fits.gz", ".fits.Z"],
+        "include subdirectory" => true,
+        "exclude files" => String[],
+        "exptime" => "EXPTIME",
+        "typefloat" => Float32)
 end
 
 """
-    read_calibration_files(yaml_file::AbstractString, ::Type{T}=Float32; kwds...) -> CalibrationData
+    read_calibration_files(yaml_file::AbstractString, config=Dict(); kwds...) -> CalibrationData
 
-Process calibration files according to the YAML configuration file `yaml_file`.
+Alias of `read_calibration_files` with a YAML file path.
+"""
+function read_calibration_files(yaml_file::AbstractString,
+                                config=Dict(),
+                                ; reset::Bool=true,
+                                  prune::Bool=true,
+                                  write_result_yaml::String="",
+                                  verbose::Bool=false)
+    yaml = YAML.load_file(normpath(yaml_file); dicttype=Dict{String,Any})
+    read_calibration_files!(yaml, config; reset, prune, write_result_yaml, verbose)
+end
+
+"""
+    read_calibration_files(yaml::AbstractDict, config=Dict(); kwds...) -> CalibrationData
+
+Process calibration files according to the `yaml` configuration.
+
+Any parameter set in `config` takes precedence over the YAML one.
 
 # Keyword parameters
-- `reset_selected_files=true`: by default, we will read files given in `dir`, and associate files to categories. However the input YAML is allowed to have existing "selected files" fields in its categories. `reset_selected_files=true` will reset these fields before searching for files.
-- `roi=(:,:)`: take only a region of interest of the input FITS files (e.g. `roi=(1:100,1:2:100)`). It's called "roi" because the input files may already have a ROI (some instruments allow it). There is no method to extract the ROI from the input FITS files yet.
-- `dir=pwd()`: directory containing the files.This keyword is overriden by the `dir` in the YAML config file.
+- `reset=true`: by default, we will read files given in `dir`, and associate files to categories. However the input YAML is allowed to have existing "selected files" fields in its categories. `reset=true` will reset these fields before searching for files.
 - `prune=true`: remove empty categories and sources
 - `write_result_yaml=""`: if a non-empty path is given, the result YAML (with the fields "selected files" filled) will be written to this path.
 
 Return an instance of `CalibrationData` with all information statistics needed to calibrate the detector.
 """
-function read_calibration_files(yaml_file::AbstractString,
-                                ::Type{T}=Float32,
-                                ; reset_selected_files::Bool=true,
-                                  roi = (:,:),
-                                  dir = pwd(),
-                                  prune::Bool=true,
-                                  write_result_yaml::String="",
-                                  verbose::Bool=false) where {T<:AbstractFloat}
-    yaml = YAML.load_file(normpath(yaml_file); dicttype=Dict{String,Any})
-    read_calibration_files!(yaml, T; reset_selected_files, roi, dir, prune, write_result_yaml, verbose)
-end
-
 function read_calibration_files!(yaml::AbstractDict,
-                                 ::Type{T}=Float32,
-                                 ; reset_selected_files::Bool=true,
-                                   roi = (:,:),
-                                   dir = pwd(),
+                                 config=Dict()
+                                 ; reset::Bool=true,
                                    prune::Bool=true,
                                    write_result_yaml::String="",
-                                   verbose::Bool=false) where {T<:AbstractFloat}
-    reset_selected_files!(yaml)
-    select_files!(yaml; roi, dir, verbose)
+                                   verbose::Bool=false)
+    reset && reset_selected_files!(yaml)
+    select_files!(yaml, config; verbose)
     isempty(write_result_yaml) || YAML.write_file(normpath(write_result_yaml), yaml)
-    calib_data = yaml_to_calibration_data(yaml, T; roi, dir, prune)
+    calib_data = yaml_to_calibration_data(yaml, config; prune)
 end
 
 function reset_selected_files!(yaml::AbstractDict)
@@ -375,33 +369,23 @@ function reset_selected_files!(yaml::AbstractDict)
     yaml
 end
 
-function select_files!(yaml_file::AbstractString,
-              ; roi = (:,:),
-                dir = pwd(),
-                files = String[],
-                include_subdirectory::Bool=true,
-                verbose::Bool=false)
+function select_files!(yaml_file::AbstractString, config=Dict(); verbose=false)
     yaml = YAML.load_file(normpath(yaml_file); dicttype=Dict{String,Any})
-    select_files!(yaml; roi, dir, files, include_subdirectory, verbose)
+    select_files!(yaml, config; verbose)
 end
 
-function select_files!(yaml::AbstractDict,
-                       ; roi = (:,:),
-                         dir = pwd(),
-                         files = String[],
-                         include_subdirectory::Bool=true,
-                         verbose::Bool=false)
+function select_files!(yaml::AbstractDict, config=Dict(); verbose=false)
 
-    global_config = get_global_config(dir, repr(roi))
-    global_config["files"] = files
-    global_config["include subdirectory"] = include_subdirectory
+    global_config = get_default_config()
     merge!(global_config, yaml)
-
+    merge!(global_config, config)
+    
     # we keep encountered FITS headers in a cache, so we have at most one I/O call by file
     headers_cache = Dict{String, FitsHeader}()
 
     for (catname,yaml_cat) in yaml["categories"]
-        cat_config = get_category_config(global_config, yaml_cat)
+        cat_config = copy(global_config)
+        merge!(cat_config, yaml_cat)
         verbose && @info "starting category \"$catname\""
 
         cat_filepaths = gather_filepaths_cat(cat_config)
@@ -435,13 +419,12 @@ function select_files!(yaml::AbstractDict,
 end
 
 function yaml_to_calibration_data(yaml::AbstractDict,
-                                  ::Type{T}=Float32
-                                  ; roi = (:,:),
-                                    dir = pwd(),
-                                    prune::Bool=true) where {T<:AbstractFloat}
+                                  config=Dict()
+                                  ; prune::Bool=true)
 
-    global_config = get_global_config(dir, repr(roi))
+    global_config = get_default_config()
     merge!(global_config, yaml)
+    merge!(global_config, config)
     
     # first pass where we:
     # - count the number of files
@@ -454,8 +437,8 @@ function yaml_to_calibration_data(yaml::AbstractDict,
     resolved_roi = nothing
     calib_cats = CalibrationCategory[]
     for (catname, yaml_cat) in yaml["categories"]
-        cat_config = get_category_config(global_config, yaml_cat)
-        
+        cat_config = copy(global_config)
+        merge!(cat_config, yaml_cat)
 
         for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
             nb_files += length(fitspaths)
@@ -475,12 +458,14 @@ function yaml_to_calibration_data(yaml::AbstractDict,
 
     iszero(nb_files) && throw(ArgumentError("no calibration file"))
 
+    T = global_config["typefloat"]
     calib_data = CalibrationData{T}(resolved_roi, calib_cats)
     
     # second pass where we read the data from FITS files
     progress = Progress(nb_files; desc="reading calibration files")
     for (catname, yaml_cat) in yaml["categories"]
-        cat_config = get_category_config(global_config, yaml_cat)
+        cat_config = copy(global_config)
+        merge!(cat_config, yaml_cat)
         
         for (Δt, fitspaths) in get(yaml_cat, "selected files", [])
             for fitspath in fitspaths

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,7 +103,7 @@ end
                """
         write(pathyaml, yaml)
         writefits!(pathfits, hdr, Int[0 0 ; 0 0])
-        read_calibration_files(pathyaml; dir=pathdir)
+        read_calibration_files(pathyaml, Dict("dir"=>pathdir))
 
     end end end
 end


### PR DESCRIPTION
- rework the setting system, so that the parameters given explicitly by the user in the julia function, takes precedence over the global parameters of the YAML. it makes sense: for example you could use a YAML file that has set the recursive directories to false, but you could want to change it from the repl. so this overwriting makes sense.
- rewrite the doc and readme accordingly
- add the typefloat setting to control the float32 or 64
- refactored a bit the settings code 